### PR TITLE
Ignore Gradle wrapper jar and document regeneration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,8 @@
 # Ignore Gradle GUI config
 gradle-app.setting
 
-# Avoid ignoring Gradle wrapper jar file (.jar files are usually ignored)
-!gradle-wrapper.jar
+# Ignore Gradle wrapper jar file
+gradle-wrapper.jar
 
 # Avoid ignore Gradle wrappper properties
 !gradle-wrapper.properties

--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
 # GetFast
+
+After cloning this repository, recreate the Gradle wrapper with:
+
+```
+gradle wrapper
+```
+
+This command generates the `gradle/wrapper/gradle-wrapper.jar` and related scripts.


### PR DESCRIPTION
## Summary
- ignore Gradle wrapper jar in version control
- document how to recreate the wrapper with `gradle wrapper`

## Testing
- `gradle test` *(fails: Directory '/workspace/GetFast' does not contain a Gradle build)*

------
https://chatgpt.com/codex/tasks/task_e_6897db3bed908326bd9c596dd1236533