### PR TITLE
Fix viewModels missing dependency and add run script

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,13 @@
 
 Android app using MVVM architecture to monitor eBay Kleinanzeigen for new housing listings. The app fetches listings from a configurable search URL, displays them in a list and triggers a local push notification for new entries.
 
+## Build & Run
+
+The project is built with Gradle. To build and install the debug APK on a connected device or emulator, run:
+
+```bash
+scripts/run.sh
+```
+
+The script will use the Gradle wrapper if available, or fall back to the system Gradle installation. Make sure the Android SDK is installed and that `ANDROID_HOME` (or `ANDROID_SDK_ROOT`) points to its location.
+

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -33,6 +33,7 @@ android {
 dependencies {
     implementation("androidx.core:core-ktx:1.12.0")
     implementation("androidx.appcompat:appcompat:1.6.1")
+    implementation("androidx.activity:activity-ktx:1.8.2")
     implementation("com.google.android.material:material:1.11.0")
     implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.7.0")
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.7.0")

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -e
+
+# Build and install the debug APK on a connected device or emulator.
+if [ -f "./gradlew" ]; then
+  ./gradlew installDebug
+else
+  gradle installDebug
+fi


### PR DESCRIPTION
## Summary
- add `androidx.activity:activity-ktx` to support `viewModels`
- document how to build and install with a helper script

## Testing
- `gradle :app:compileDebugKotlin` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a10c64d5c83269444b8cd0ed62ba0