### PR TITLE
Fix missing Material3 theme dependency and add unit test

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -46,6 +46,7 @@ dependencies {
     implementation("androidx.compose.ui:ui")
     implementation("androidx.compose.ui:ui-tooling-preview")
     implementation("androidx.compose.material3:material3")
+    implementation("com.google.android.material:material:1.11.0")
 
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3")
     implementation("org.jsoup:jsoup:1.17.2")
@@ -53,6 +54,8 @@ dependencies {
     debugImplementation("androidx.compose.ui:ui-tooling")
 
     testImplementation("junit:junit:4.13.2")
+    testImplementation("androidx.test:core:1.5.0")
+    testImplementation("org.robolectric:robolectric:4.11.1")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
 }

--- a/app/src/test/java/com/example/getfast/ThemeTest.kt
+++ b/app/src/test/java/com/example/getfast/ThemeTest.kt
@@ -1,0 +1,21 @@
+package com.example.getfast
+
+import android.content.Context
+import android.util.TypedValue
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class ThemeTest {
+    @Test
+    fun themeIsResolvable() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        context.setTheme(R.style.Theme_GetFast)
+        val typedValue = TypedValue()
+        val resolved = context.theme.resolveAttribute(android.R.attr.colorBackground, typedValue, true)
+        assertTrue("Theme should resolve colorBackground attribute", resolved)
+    }
+}


### PR DESCRIPTION
## Summary
- add Material Components dependency so Theme.Material3.DayNight.NoActionBar resolves
- add Robolectric test verifying app theme resolves

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a18e496d083268d886afdcd1103e1