### PR TITLE
Combine meta line and mark fresh listings

### DIFF
--- a/app/src/main/java/com/example/getfast/ui/components/ListingComponents.kt
+++ b/app/src/main/java/com/example/getfast/ui/components/ListingComponents.kt
@@ -32,9 +32,14 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.example.getfast.R
 import com.example.getfast.model.Listing
+import com.example.getfast.utils.ListingDateUtils
 
 @Composable
 fun ListingList(
@@ -136,14 +141,24 @@ fun ListingCard(
                     }
                 }
             }
+            val isNew = ListingDateUtils.isRecent(listing.date)
             Text(
-                text = "${listing.date} • ${listing.district}, ${listing.city}",
-                style = MaterialTheme.typography.bodyMedium
-            )
-            Text(
-                text = listing.price,
+                text = buildAnnotatedString {
+                    append(listing.date)
+                    if (isNew) {
+                        append(" ")
+                        withStyle(SpanStyle(color = MaterialTheme.colorScheme.error)) {
+                            append("NEU")
+                        }
+                    }
+                    append(" • ${listing.district}, ${listing.city} • ")
+                    withStyle(SpanStyle(color = MaterialTheme.colorScheme.secondary)) {
+                        append(listing.price)
+                    }
+                },
                 style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.secondary
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis
             )
             Text(
                 text = listing.summary,

--- a/app/src/main/java/com/example/getfast/utils/ListingDateUtils.kt
+++ b/app/src/main/java/com/example/getfast/utils/ListingDateUtils.kt
@@ -1,0 +1,34 @@
+package com.example.getfast.utils
+
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+object ListingDateUtils {
+    private val dateTimeFormatter = SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.getDefault())
+    private val dateFormatter = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
+
+    fun isRecent(dateString: String, now: Date = Date()): Boolean {
+        return try {
+            val listingDate = parseDate(dateString) ?: return false
+            val diff = now.time - listingDate.time
+            diff in 0 until 10 * 60 * 1000
+        } catch (_: Exception) {
+            false
+        }
+    }
+
+    private fun parseDate(dateString: String): Date? {
+        return try {
+            if (dateString.startsWith("Heute")) {
+                val timePart = dateString.substringAfter(",").trim().take(5)
+                val today = dateFormatter.format(Date())
+                dateTimeFormatter.parse("$today $timePart")
+            } else {
+                null
+            }
+        } catch (_: Exception) {
+            null
+        }
+    }
+}

--- a/app/src/main/java/com/example/getfast/viewmodel/ListingViewModel.kt
+++ b/app/src/main/java/com/example/getfast/viewmodel/ListingViewModel.kt
@@ -27,7 +27,7 @@ class ListingViewModel(
 
     fun refreshListings() {
         viewModelScope.launch {
-            _listings.value = repository.fetchLatestListings().reversed()
+            _listings.value = repository.fetchLatestListings()
             _lastFetchTime.value = formatter.format(Date())
         }
     }


### PR DESCRIPTION
## Summary
- Display time, location, and price on a single annotated line and highlight very recent listings
- Remove reverse sort so newest listings appear at the top
- Add `ListingDateUtils` utility to encapsulate "new" detection logic

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a3f2733648326924c0f7778b7eafc