### PR TITLE
Improve listing refresh and status indicators

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -46,6 +46,7 @@ dependencies {
     implementation("androidx.compose.ui:ui")
     implementation("androidx.compose.ui:ui-tooling-preview")
     implementation("androidx.compose.material3:material3")
+    implementation("androidx.compose.material:pullrefresh")
     implementation("com.google.android.material:material:1.11.0")
 
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3")

--- a/app/src/main/java/com/example/getfast/ui/MainActivity.kt
+++ b/app/src/main/java/com/example/getfast/ui/MainActivity.kt
@@ -12,10 +12,10 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Tab
-import androidx.compose.material3.TabRow
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -37,11 +37,13 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         val notifier = Notifier(this)
+        @OptIn(ExperimentalMaterial3Api::class)
         setContent {
             MaterialTheme {
                 val listings by viewModel.listings.collectAsState()
                 val lastFetch by viewModel.lastFetchTime.collectAsState()
                 val favorites by viewModel.favorites.collectAsState()
+                val isRefreshing by viewModel.isRefreshing.collectAsState()
                 var showFavoritesOnly by remember { mutableStateOf(false) }
                 val seenIds = remember { mutableSetOf<String>() }
                 LaunchedEffect(listings) {
@@ -71,19 +73,30 @@ class MainActivity : ComponentActivity() {
                             Text(text = stringResource(id = R.string.refresh))
                         }
                     }
-                    TabRow(selectedTabIndex = if (showFavoritesOnly) 1 else 0) {
-                        Tab(selected = !showFavoritesOnly, onClick = { showFavoritesOnly = false }) {
-                            Text(text = stringResource(id = R.string.all_tab))
-                        }
-                        Tab(selected = showFavoritesOnly, onClick = { showFavoritesOnly = true }) {
-                            Text(text = stringResource(id = R.string.favorites_tab))
-                        }
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 8.dp, vertical = 4.dp),
+                    ) {
+                        FilterChip(
+                            selected = !showFavoritesOnly,
+                            onClick = { showFavoritesOnly = false },
+                            label = { Text(text = stringResource(id = R.string.all_tab)) },
+                        )
+                        Spacer(modifier = Modifier.weight(1f))
+                        FilterChip(
+                            selected = showFavoritesOnly,
+                            onClick = { showFavoritesOnly = true },
+                            label = { Text(text = stringResource(id = R.string.favorites_tab)) },
+                        )
                     }
                     ListingList(
                         listings = listings,
                         favorites = favorites,
                         favoritesOnly = showFavoritesOnly,
                         onToggleFavorite = { viewModel.toggleFavorite(it) },
+                        onRefresh = { viewModel.refreshListings() },
+                        isRefreshing = isRefreshing,
                         modifier = Modifier.weight(1f)
                     )
                     Text(

--- a/app/src/main/java/com/example/getfast/utils/ListingDateUtils.kt
+++ b/app/src/main/java/com/example/getfast/utils/ListingDateUtils.kt
@@ -10,7 +10,7 @@ object ListingDateUtils {
 
     fun isRecent(dateString: String, now: Date = Date()): Boolean {
         return try {
-            val listingDate = parseDate(dateString) ?: return false
+            val listingDate = parseDate(dateString, now) ?: return false
             val diff = now.time - listingDate.time
             diff in 0 until 10 * 60 * 1000
         } catch (_: Exception) {
@@ -18,14 +18,20 @@ object ListingDateUtils {
         }
     }
 
-    private fun parseDate(dateString: String): Date? {
+    private fun parseDate(dateString: String, now: Date): Date? {
         return try {
-            if (dateString.startsWith("Heute")) {
-                val timePart = dateString.substringAfter(",").trim().take(5)
-                val today = dateFormatter.format(Date())
-                dateTimeFormatter.parse("$today $timePart")
-            } else {
-                null
+            when {
+                dateString.startsWith("Heute") -> {
+                    val timePart = dateString.substringAfter(",").trim().take(5)
+                    val today = dateFormatter.format(now)
+                    dateTimeFormatter.parse("$today $timePart")
+                }
+                dateString.startsWith("Vor") -> {
+                    val minutes = Regex("Vor\\s+(\\d+)\\s+Min").find(dateString)?.groupValues?.get(1)?.toIntOrNull()
+                    minutes?.let { Date(now.time - it * 60 * 1000) }
+                }
+                dateString.startsWith("Gerade") -> now
+                else -> null
             }
         } catch (_: Exception) {
             null

--- a/app/src/main/java/com/example/getfast/viewmodel/ListingViewModel.kt
+++ b/app/src/main/java/com/example/getfast/viewmodel/ListingViewModel.kt
@@ -4,9 +4,8 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.getfast.model.Listing
 import com.example.getfast.repository.EbayRepository
-import java.text.SimpleDateFormat
+import java.text.DateFormat
 import java.util.Date
-import java.util.Locale
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -18,17 +17,22 @@ class ListingViewModel(
     private val _listings = MutableStateFlow<List<Listing>>(emptyList())
     val listings: StateFlow<List<Listing>> = _listings
 
-    private val formatter = SimpleDateFormat("HH:mm:ss dd.MM.yyyy", Locale.getDefault())
+    private val formatter = DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.SHORT)
     private val _lastFetchTime = MutableStateFlow<String?>(null)
     val lastFetchTime: StateFlow<String?> = _lastFetchTime
 
     private val _favorites = MutableStateFlow<Set<String>>(emptySet())
     val favorites: StateFlow<Set<String>> = _favorites
 
+    private val _isRefreshing = MutableStateFlow(false)
+    val isRefreshing: StateFlow<Boolean> = _isRefreshing
+
     fun refreshListings() {
         viewModelScope.launch {
+            _isRefreshing.value = true
             _listings.value = repository.fetchLatestListings()
             _lastFetchTime.value = formatter.format(Date())
+            _isRefreshing.value = false
         }
     }
 


### PR DESCRIPTION
## Summary
- Show a red "Neu" tag for recent listings and support relative timestamps like "Vor 5 Min"
- Add pull-to-refresh and localized last update time
- Replace tab bar with Material chips for switching favorites and main list

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a41d84c0883268b2e429193aea529