### PR TITLE
Specify version for Compose pullrefresh dependency

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -46,7 +46,7 @@ dependencies {
     implementation("androidx.compose.ui:ui")
     implementation("androidx.compose.ui:ui-tooling-preview")
     implementation("androidx.compose.material3:material3")
-    implementation("androidx.compose.material:pullrefresh")
+    implementation("androidx.compose.material:pullrefresh:1.5.0")
     implementation("com.google.android.material:material:1.11.0")
 
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3")


### PR DESCRIPTION
## Summary
- specify `androidx.compose.material:pullrefresh` version to avoid missing dependency

## Testing
- `gradle assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a501e255883268db8522b67221c92