### PR TITLE
Fix pull refresh dependency resolution

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -46,7 +46,8 @@ dependencies {
     implementation("androidx.compose.ui:ui")
     implementation("androidx.compose.ui:ui-tooling-preview")
     implementation("androidx.compose.material3:material3")
-    implementation("androidx.compose.material:pullrefresh:1.5.0")
+    // Use version provided by the Compose BOM for pull refresh APIs
+    implementation("androidx.compose.material:pullrefresh")
     implementation("com.google.android.material:material:1.11.0")
 
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3")


### PR DESCRIPTION
## Summary
- use Compose BOM-managed version for `androidx.compose.material:pullrefresh`

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a53c239f8832690c86b10deb75d54