### PR TITLE
Replace deprecated pullrefresh dependency

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -46,8 +46,8 @@ dependencies {
     implementation("androidx.compose.ui:ui")
     implementation("androidx.compose.ui:ui-tooling-preview")
     implementation("androidx.compose.material3:material3")
-    // Use version provided by the Compose BOM for pull refresh APIs
-    implementation("androidx.compose.material:pullrefresh")
+    // Material library is required for pull-to-refresh APIs and icons
+    implementation("androidx.compose.material:material")
     implementation("com.google.android.material:material:1.11.0")
 
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3")


### PR DESCRIPTION
## Summary
- replace `androidx.compose.material:pullrefresh` with `androidx.compose.material:material` to supply pull-to-refresh APIs and icons

## Testing
- `gradle build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a5769ccc88326902725735e32975a