### PR TITLE
Specify version for pull refresh dependency

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -46,8 +46,8 @@ dependencies {
     implementation("androidx.compose.ui:ui")
     implementation("androidx.compose.ui:ui-tooling-preview")
     implementation("androidx.compose.material3:material3")
-    // Use version provided by the Compose BOM for pull refresh APIs
-    implementation("androidx.compose.material:pullrefresh")
+    // Explicitly declare pull refresh dependency until it's included in the Compose BOM
+    implementation("androidx.compose.material:pullrefresh:1.1.0")
     implementation("com.google.android.material:material:1.11.0")
 
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3")


### PR DESCRIPTION
## Summary
- explicitly declare compose pull refresh dependency version

## Testing
- `gradle assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a5a2bf140832684eaf238881efc07