### PR TITLE
Remove pullrefresh dependency and switch to accompanist SwipeRefresh

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -46,8 +46,7 @@ dependencies {
     implementation("androidx.compose.ui:ui")
     implementation("androidx.compose.ui:ui-tooling-preview")
     implementation("androidx.compose.material3:material3")
-    // Use version provided by the Compose BOM for pull refresh APIs
-    implementation("androidx.compose.material:pullrefresh")
+    implementation("com.google.accompanist:accompanist-swiperefresh:0.32.0")
     implementation("com.google.android.material:material:1.11.0")
 
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3")

--- a/app/src/main/java/com/example/getfast/ui/components/ListingComponents.kt
+++ b/app/src/main/java/com/example/getfast/ui/components/ListingComponents.kt
@@ -10,10 +10,8 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.layout.Box
-import androidx.compose.material.pullrefresh.PullRefreshIndicator
-import androidx.compose.material.pullrefresh.pullRefresh
-import androidx.compose.material.pullrefresh.rememberPullRefreshState
+import com.google.accompanist.swiperefresh.SwipeRefresh
+import com.google.accompanist.swiperefresh.rememberSwipeRefreshState
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Favorite
@@ -66,11 +64,12 @@ fun ListingList(
         listings
     }
 
-    val pullRefreshState = rememberPullRefreshState(isRefreshing, onRefresh)
-    Box(
+    val swipeRefreshState = rememberSwipeRefreshState(isRefreshing)
+    SwipeRefresh(
+        state = swipeRefreshState,
+        onRefresh = onRefresh,
         modifier = modifier
             .fillMaxSize()
-            .pullRefresh(pullRefreshState)
             .padding(16.dp)
             .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.1f))
     ) {
@@ -83,11 +82,6 @@ fun ListingList(
                 ) { selectedListing = listing }
             }
         }
-        PullRefreshIndicator(
-            refreshing = isRefreshing,
-            state = pullRefreshState,
-            modifier = Modifier.align(Alignment.TopCenter)
-        )
     }
 
     selectedListing?.let { listing ->


### PR DESCRIPTION
## Summary
- drop androidx.compose.material:pullrefresh dependency
- add accompanist swiperefresh and update listings list to use SwipeRefresh

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b9aa5429c8326ac0690f563288ac3