### PR TITLE
Improve Android SDK setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,22 @@ Android app using MVVM architecture to monitor eBay Kleinanzeigen for new housin
 
 ## Build & Run
 
-The project is built with Gradle. To build and install the debug APK on a connected device or emulator, run:
+The project is built with Gradle. On Windows, build the debug APK with:
 
-```bash
-scripts/run.sh
+```
+gradle assembleDebug
 ```
 
-The script will use the Gradle wrapper if available, or fall back to the system Gradle installation. Make sure the Android SDK is installed and that `ANDROID_HOME` (or `ANDROID_SDK_ROOT`) points to its location.
+If the build fails with `SDK location not found`, define the Android SDK path:
 
+```
+setx ANDROID_SDK_ROOT "C:\Users\<you>\AppData\Local\Android\Sdk"
+```
+
+After setting the variable, you can optionally run the helper script to generate `local.properties`:
+
+```
+scripts\setup-sdk.ps1
+```
+
+The PowerShell script only writes the `local.properties` file so Gradle can locate the SDK.

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-set -e
-
-# Build and install the debug APK on a connected device or emulator.
-if [ -f "./gradlew" ]; then
-  ./gradlew installDebug
-else
-  gradle installDebug
-fi

--- a/scripts/setup-sdk.ps1
+++ b/scripts/setup-sdk.ps1
@@ -1,0 +1,23 @@
+$ErrorActionPreference = 'Stop'
+
+# Determine Android SDK path from environment variables
+$sdk = $Env:ANDROID_SDK_ROOT
+if (-not $sdk) {
+    $sdk = $Env:ANDROID_HOME
+}
+if (-not $sdk) {
+    Write-Error 'Android SDK not found. Set ANDROID_SDK_ROOT or ANDROID_HOME.'
+}
+
+$sdkPath = [System.IO.Path]::GetFullPath($sdk)
+Write-Host "Using Android SDK at $sdkPath"
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$localProps = Join-Path $repoRoot 'local.properties'
+
+if (-not (Test-Path $localProps)) {
+    Set-Content -Path $localProps -Value "sdk.dir=$sdkPath"
+    Write-Host 'Created local.properties'
+} else {
+    Write-Host 'local.properties already exists; no changes made.'
+}


### PR DESCRIPTION
## Summary
- Replace Linux run script with optional Windows PowerShell helper
- Document Windows build commands and optional script for fixing missing SDK

## Testing
- `pwsh scripts/setup-sdk.ps1` *(fails: command not found)*
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b9a3778ac83268f8b9d78fa45f3b8