### PR TITLE
Replace SwipeRefresh with Material3 pull refresh

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -46,7 +46,6 @@ dependencies {
     implementation("androidx.compose.ui:ui")
     implementation("androidx.compose.ui:ui-tooling-preview")
     implementation("androidx.compose.material3:material3")
-    implementation("com.google.accompanist:accompanist-swiperefresh:0.32.0")
     implementation("com.google.android.material:material:1.11.0")
 
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3")

--- a/app/src/main/java/com/example/getfast/ui/components/ListingComponents.kt
+++ b/app/src/main/java/com/example/getfast/ui/components/ListingComponents.kt
@@ -3,6 +3,7 @@ package com.example.getfast.ui.components
 import android.content.Intent
 import android.net.Uri
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
@@ -10,9 +11,9 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import com.google.accompanist.swiperefresh.SwipeRefresh
-import com.google.accompanist.swiperefresh.rememberSwipeRefreshState
-import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material3.pullrefresh.PullRefreshIndicator
+import androidx.compose.material3.pullrefresh.pullRefresh
+import androidx.compose.material3.pullrefresh.rememberPullRefreshState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.outlined.FavoriteBorder
@@ -44,7 +45,7 @@ import com.example.getfast.R
 import com.example.getfast.model.Listing
 import com.example.getfast.utils.ListingDateUtils
 
-@OptIn(ExperimentalMaterialApi::class)
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ListingList(
     listings: List<Listing>,
@@ -64,14 +65,13 @@ fun ListingList(
         listings
     }
 
-    val swipeRefreshState = rememberSwipeRefreshState(isRefreshing)
-    SwipeRefresh(
-        state = swipeRefreshState,
-        onRefresh = onRefresh,
+    val pullRefreshState = rememberPullRefreshState(isRefreshing, onRefresh)
+    Box(
         modifier = modifier
             .fillMaxSize()
             .padding(16.dp)
             .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.1f))
+            .pullRefresh(pullRefreshState)
     ) {
         LazyColumn(modifier = Modifier.fillMaxSize()) {
             items(shownListings) { listing ->
@@ -82,6 +82,11 @@ fun ListingList(
                 ) { selectedListing = listing }
             }
         }
+        PullRefreshIndicator(
+            refreshing = isRefreshing,
+            state = pullRefreshState,
+            modifier = Modifier.align(Alignment.TopCenter)
+        )
     }
 
     selectedListing?.let { listing ->


### PR DESCRIPTION
## Summary
- drop accompanist SwipeRefresh and use Material3 pull refresh
- remove accompanist dependency from build script

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b9f3f25448326962e349a51a795ca