### PR TITLE
Remove pull refresh dependencies

### DIFF
--- a/app/src/main/java/com/example/getfast/ui/MainActivity.kt
+++ b/app/src/main/java/com/example/getfast/ui/MainActivity.kt
@@ -15,7 +15,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.FilterChip
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -37,13 +36,11 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         val notifier = Notifier(this)
-        @OptIn(ExperimentalMaterial3Api::class)
         setContent {
             MaterialTheme {
                 val listings by viewModel.listings.collectAsState()
                 val lastFetch by viewModel.lastFetchTime.collectAsState()
                 val favorites by viewModel.favorites.collectAsState()
-                val isRefreshing by viewModel.isRefreshing.collectAsState()
                 var showFavoritesOnly by remember { mutableStateOf(false) }
                 val seenIds = remember { mutableSetOf<String>() }
                 LaunchedEffect(listings) {
@@ -95,8 +92,6 @@ class MainActivity : ComponentActivity() {
                         favorites = favorites,
                         favoritesOnly = showFavoritesOnly,
                         onToggleFavorite = { viewModel.toggleFavorite(it) },
-                        onRefresh = { viewModel.refreshListings() },
-                        isRefreshing = isRefreshing,
                         modifier = Modifier.weight(1f)
                     )
                     Text(

--- a/app/src/main/java/com/example/getfast/ui/components/ListingComponents.kt
+++ b/app/src/main/java/com/example/getfast/ui/components/ListingComponents.kt
@@ -3,7 +3,7 @@ package com.example.getfast.ui.components
 import android.content.Intent
 import android.net.Uri
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
@@ -11,9 +11,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material3.pullrefresh.PullRefreshIndicator
-import androidx.compose.material3.pullrefresh.pullRefresh
-import androidx.compose.material3.pullrefresh.rememberPullRefreshState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.outlined.FavoriteBorder
@@ -23,7 +20,6 @@ import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconToggleButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -45,15 +41,12 @@ import com.example.getfast.R
 import com.example.getfast.model.Listing
 import com.example.getfast.utils.ListingDateUtils
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ListingList(
     listings: List<Listing>,
     favorites: Set<String>,
     favoritesOnly: Boolean,
     onToggleFavorite: (Listing) -> Unit,
-    onRefresh: () -> Unit,
-    isRefreshing: Boolean,
     modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
@@ -65,28 +58,19 @@ fun ListingList(
         listings
     }
 
-    val pullRefreshState = rememberPullRefreshState(isRefreshing, onRefresh)
-    Box(
+    LazyColumn(
         modifier = modifier
             .fillMaxSize()
             .padding(16.dp)
             .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.1f))
-            .pullRefresh(pullRefreshState)
     ) {
-        LazyColumn(modifier = Modifier.fillMaxSize()) {
-            items(shownListings) { listing ->
-                ListingCard(
-                    listing = listing,
-                    isFavorite = favorites.contains(listing.id),
-                    onToggleFavorite = onToggleFavorite
-                ) { selectedListing = listing }
-            }
+        items(shownListings) { listing ->
+            ListingCard(
+                listing = listing,
+                isFavorite = favorites.contains(listing.id),
+                onToggleFavorite = onToggleFavorite
+            ) { selectedListing = listing }
         }
-        PullRefreshIndicator(
-            refreshing = isRefreshing,
-            state = pullRefreshState,
-            modifier = Modifier.align(Alignment.TopCenter)
-        )
     }
 
     selectedListing?.let { listing ->
@@ -119,7 +103,6 @@ fun ListingList(
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ListingCard(
     listing: Listing,
@@ -130,9 +113,9 @@ fun ListingCard(
     Card(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(vertical = 8.dp),
+            .padding(vertical = 8.dp)
+            .clickable(onClick = onClick),
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
-        onClick = onClick
     ) {
         Column(modifier = Modifier.padding(16.dp)) {
             Row(verticalAlignment = Alignment.CenterVertically) {


### PR DESCRIPTION
## Summary
- remove PullRefresh imports and state from listing UI
- drop ExperimentalMaterial3Api usage and switch card clicks to Modifier.clickable
- simplify main activity list call accordingly

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ba29408448326b982f11abf97cd59