### PR TITLE
Add search tab and highlight new listings

### DIFF
--- a/app/src/main/java/com/example/getfast/model/Listing.kt
+++ b/app/src/main/java/com/example/getfast/model/Listing.kt
@@ -8,5 +8,6 @@ data class Listing(
     val district: String,
     val city: String,
     val price: String,
-    val summary: String
+    val summary: String,
+    val isSearch: Boolean = false,
 )

--- a/app/src/main/java/com/example/getfast/repository/EbayRepository.kt
+++ b/app/src/main/java/com/example/getfast/repository/EbayRepository.kt
@@ -38,6 +38,9 @@ class EbayRepository(
         val price = element.selectFirst(".aditem-main--middle--price-shipping")?.text()?.trim() ?: ""
         val description = element.selectFirst(".aditem-main--middle--description")?.text()?.trim() ?: ""
         val summary = generateSummary(description)
+        val isSearch = listOf(title, description).any {
+            it.contains("suche", ignoreCase = true) || it.contains("gesuch", ignoreCase = true)
+        }
         return Listing(
             id = id,
             title = title,
@@ -46,7 +49,8 @@ class EbayRepository(
             district = district,
             city = city,
             price = price,
-            summary = summary
+            summary = summary,
+            isSearch = isSearch,
         )
     }
 

--- a/app/src/main/java/com/example/getfast/ui/MainActivity.kt
+++ b/app/src/main/java/com/example/getfast/ui/MainActivity.kt
@@ -12,10 +12,12 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Tab
+import androidx.compose.material3.TabRow
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
-import androidx.compose.material3.FilterChip
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -23,12 +25,14 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import com.example.getfast.R
 import com.example.getfast.notifications.Notifier
 import com.example.getfast.ui.components.ListingList
+import com.example.getfast.ui.theme.GetFastTheme
 import com.example.getfast.viewmodel.ListingViewModel
-import com.example.getfast.R
 
 class MainActivity : ComponentActivity() {
 
@@ -39,38 +43,61 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         val notifier = Notifier(this)
         setContent {
-            MaterialTheme {
+            GetFastTheme {
                 val listings by viewModel.listings.collectAsState()
                 val lastFetch by viewModel.lastFetchTime.collectAsState()
                 val favorites by viewModel.favorites.collectAsState()
                 var showFavoritesOnly by remember { mutableStateOf(false) }
+                var currentTab by remember { mutableStateOf(ListingTab.OFFERS) }
                 val seenIds = remember { mutableSetOf<String>() }
                 LaunchedEffect(listings) {
                     val newItems = listings.filter { it.id !in seenIds }
                     newItems.forEach { notifier.notifyNewListing(it.title) }
                     seenIds.addAll(newItems.map { it.id })
                 }
+                val tabFiltered = listings.filter {
+                    if (currentTab == ListingTab.SEARCH) it.isSearch else !it.isSearch
+                }
                 Column(
                     modifier = Modifier
                         .fillMaxSize()
-                        .background(MaterialTheme.colorScheme.background)
+                        .background(
+                            Brush.verticalGradient(
+                                colors = listOf(
+                                    MaterialTheme.colorScheme.primary.copy(alpha = 0.05f),
+                                    MaterialTheme.colorScheme.background,
+                                ),
+                            ),
+                        ),
                 ) {
                     Row(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .padding(8.dp)
+                            .padding(8.dp),
                     ) {
                         Text(
                             text = stringResource(
                                 id = R.string.last_fetch,
-                                lastFetch ?: "--"
+                                lastFetch ?: "--",
                             ),
-                            style = MaterialTheme.typography.bodySmall
+                            style = MaterialTheme.typography.bodySmall,
                         )
                         Spacer(modifier = Modifier.weight(1f))
                         TextButton(onClick = { viewModel.refreshListings() }) {
                             Text(text = stringResource(id = R.string.refresh))
                         }
+                    }
+                    TabRow(selectedTabIndex = currentTab.ordinal) {
+                        Tab(
+                            selected = currentTab == ListingTab.OFFERS,
+                            onClick = { currentTab = ListingTab.OFFERS },
+                            text = { Text(text = stringResource(id = R.string.offers_tab)) },
+                        )
+                        Tab(
+                            selected = currentTab == ListingTab.SEARCH,
+                            onClick = { currentTab = ListingTab.SEARCH },
+                            text = { Text(text = stringResource(id = R.string.search_tab)) },
+                        )
                     }
                     Row(
                         modifier = Modifier
@@ -90,16 +117,16 @@ class MainActivity : ComponentActivity() {
                         )
                     }
                     ListingList(
-                        listings = listings,
+                        listings = tabFiltered,
                         favorites = favorites,
                         favoritesOnly = showFavoritesOnly,
                         onToggleFavorite = { viewModel.toggleFavorite(it) },
-                        modifier = Modifier.weight(1f)
+                        modifier = Modifier.weight(1f),
                     )
                     Text(
                         text = stringResource(id = R.string.copyright),
                         modifier = Modifier.padding(8.dp),
-                        style = MaterialTheme.typography.bodySmall
+                        style = MaterialTheme.typography.bodySmall,
                     )
                 }
             }
@@ -107,4 +134,3 @@ class MainActivity : ComponentActivity() {
         viewModel.refreshListings()
     }
 }
-

--- a/app/src/main/java/com/example/getfast/ui/Tabs.kt
+++ b/app/src/main/java/com/example/getfast/ui/Tabs.kt
@@ -1,0 +1,6 @@
+package com.example.getfast.ui
+
+enum class ListingTab {
+    OFFERS,
+    SEARCH
+}

--- a/app/src/main/java/com/example/getfast/ui/components/ListingComponents.kt
+++ b/app/src/main/java/com/example/getfast/ui/components/ListingComponents.kt
@@ -29,6 +29,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontStyle
@@ -62,7 +63,14 @@ fun ListingList(
         modifier = modifier
             .fillMaxSize()
             .padding(16.dp)
-            .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.1f))
+            .background(
+                Brush.verticalGradient(
+                    colors = listOf(
+                        MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.2f),
+                        MaterialTheme.colorScheme.surface,
+                    ),
+                ),
+            )
     ) {
         items(shownListings) { listing ->
             ListingCard(
@@ -147,7 +155,7 @@ fun ListingCard(
                     if (isNew) {
                         append(" ")
                         withStyle(SpanStyle(color = MaterialTheme.colorScheme.error)) {
-                            append("Neu")
+                            append("NEU")
                         }
                     }
                     append(" • ${listing.district}, ${listing.city} • ")

--- a/app/src/main/java/com/example/getfast/ui/theme/Color.kt
+++ b/app/src/main/java/com/example/getfast/ui/theme/Color.kt
@@ -1,0 +1,9 @@
+package com.example.getfast.ui.theme
+
+import androidx.compose.ui.graphics.Color
+
+val GreenPrimary = Color(0xFF00695C)
+val GreenSecondary = Color(0xFF26A69A)
+val LightBackground = Color(0xFFF0F4F7)
+val SurfaceColor = Color(0xFFFFFFFF)
+val ErrorColor = Color(0xFFB00020)

--- a/app/src/main/java/com/example/getfast/ui/theme/Theme.kt
+++ b/app/src/main/java/com/example/getfast/ui/theme/Theme.kt
@@ -1,0 +1,22 @@
+package com.example.getfast.ui.theme
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.runtime.Composable
+
+private val LightColors = lightColorScheme(
+    primary = GreenPrimary,
+    secondary = GreenSecondary,
+    background = LightBackground,
+    surface = SurfaceColor,
+    error = ErrorColor,
+)
+
+@Composable
+fun GetFastTheme(content: @Composable () -> Unit) {
+    MaterialTheme(
+        colorScheme = LightColors,
+        typography = Typography,
+        content = content
+    )
+}

--- a/app/src/main/java/com/example/getfast/ui/theme/Type.kt
+++ b/app/src/main/java/com/example/getfast/ui/theme/Type.kt
@@ -1,0 +1,5 @@
+package com.example.getfast.ui.theme
+
+import androidx.compose.material3.Typography
+
+val Typography = Typography()

--- a/app/src/main/java/com/example/getfast/utils/ListingDateUtils.kt
+++ b/app/src/main/java/com/example/getfast/utils/ListingDateUtils.kt
@@ -27,7 +27,8 @@ object ListingDateUtils {
                     dateTimeFormatter.parse("$today $timePart")
                 }
                 dateString.startsWith("Vor") -> {
-                    val minutes = Regex("Vor\\s+(\\d+)\\s+Min").find(dateString)?.groupValues?.get(1)?.toIntOrNull()
+                    val minutes = Regex("Vor\\s+(\\d+)\\s+Min(?:\\.|uten)?", RegexOption.IGNORE_CASE)
+                        .find(dateString)?.groupValues?.get(1)?.toIntOrNull()
                     minutes?.let { Date(now.time - it * 60 * 1000) }
                 }
                 dateString.startsWith("Gerade") -> now

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -9,5 +9,7 @@
     <string name="open_in_app">In App öffnen</string>
     <string name="open_in_browser">Im Browser öffnen</string>
     <string name="open_listing">Anzeige öffnen</string>
+    <string name="offers_tab">Angebote</string>
+    <string name="search_tab">Suche</string>
     <string name="copyright">\u00A9 2024 Christian Meyer</string>
 </resources>


### PR DESCRIPTION
## Summary
- categorize listings by offer or search and add a tab row to switch between them
- show red **NEU** badge for recent listings and fix date parsing for "Vor X Min."
- introduce reusable theme with a custom color scheme and gradient backgrounds

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ba6bba76c8326a6220c7669faa21e