### PR TITLE
Add city and price filters for listings

### DIFF
--- a/app/src/main/java/com/example/getfast/model/SearchFilter.kt
+++ b/app/src/main/java/com/example/getfast/model/SearchFilter.kt
@@ -1,0 +1,23 @@
+package com.example.getfast.model
+
+/**
+ * Represents user-defined search filtering options.
+ *
+ * @property city      City to search within. Controls the remote search URL.
+ * @property maxPrice  Optional maximum price in Euro. Listings above this price
+ *                     will be filtered out after retrieval.
+ */
+data class SearchFilter(
+    val city: City = City.BERLIN,
+    val maxPrice: Int? = null,
+)
+
+/**
+ * Limited set of supported cities and their respective URL paths on Kleinanzeigen.
+ * The structure makes it easy to extend with additional cities in the future.
+ */
+enum class City(val displayName: String, val urlPath: String) {
+    BERLIN("Berlin", "berlin/c203l3331"),
+    HAMBURG("Hamburg", "hamburg/c203l9409"),
+    MUNICH("München", "muenchen/c203l6436"),
+}

--- a/app/src/main/java/com/example/getfast/ui/MainActivity.kt
+++ b/app/src/main/java/com/example/getfast/ui/MainActivity.kt
@@ -14,9 +14,16 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Button
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Tab
 import androidx.compose.material3.TabRow
 import androidx.compose.material3.Text
@@ -31,6 +38,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import com.example.getfast.model.City
+import com.example.getfast.model.SearchFilter
 import com.example.getfast.R
 import com.example.getfast.notifications.Notifier
 import com.example.getfast.ui.components.ListingList
@@ -64,8 +73,15 @@ class MainActivity : ComponentActivity() {
                 val listings by viewModel.listings.collectAsState()
                 val lastFetch by viewModel.lastFetchTime.collectAsState()
                 val favorites by viewModel.favorites.collectAsState()
+                val filter by viewModel.filter.collectAsState()
                 var showFavoritesOnly by remember { mutableStateOf(false) }
                 var currentTab by remember { mutableStateOf(ListingTab.OFFERS) }
+                var selectedCity by remember { mutableStateOf(filter.city) }
+                var priceText by remember { mutableStateOf(filter.maxPrice?.toString() ?: "") }
+                LaunchedEffect(filter) {
+                    selectedCity = filter.city
+                    priceText = filter.maxPrice?.toString() ?: ""
+                }
                 val seenIds = remember { mutableSetOf<String>() }
                 val blinkingIds = remember { mutableStateOf<Set<String>>(emptySet()) }
                 LaunchedEffect(listings) {
@@ -111,6 +127,63 @@ class MainActivity : ComponentActivity() {
                         Spacer(modifier = Modifier.weight(1f))
                         TextButton(onClick = { viewModel.refreshListings() }) {
                             Text(text = stringResource(id = R.string.refresh))
+                        }
+                    }
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 8.dp, vertical = 4.dp),
+                    ) {
+                        var expanded by remember { mutableStateOf(false) }
+                        ExposedDropdownMenuBox(
+                            expanded = expanded,
+                            onExpandedChange = { expanded = !expanded },
+                            modifier = Modifier.weight(1f),
+                        ) {
+                            OutlinedTextField(
+                                value = selectedCity.displayName,
+                                onValueChange = {},
+                                label = { Text(text = stringResource(id = R.string.city_label)) },
+                                readOnly = true,
+                                trailingIcon = {
+                                    ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded)
+                                },
+                                modifier = Modifier
+                                    .menuAnchor()
+                                    .fillMaxWidth(),
+                            )
+                            DropdownMenu(
+                                expanded = expanded,
+                                onDismissRequest = { expanded = false },
+                            ) {
+                                City.values().forEach { city ->
+                                    DropdownMenuItem(
+                                        text = { Text(city.displayName) },
+                                        onClick = {
+                                            selectedCity = city
+                                            expanded = false
+                                        },
+                                    )
+                                }
+                            }
+                        }
+                        Spacer(modifier = Modifier.width(8.dp))
+                        OutlinedTextField(
+                            value = priceText,
+                            onValueChange = { priceText = it.filter { ch -> ch.isDigit() } },
+                            label = { Text(text = stringResource(id = R.string.max_price_label)) },
+                            modifier = Modifier.weight(1f),
+                        )
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Button(onClick = {
+                            viewModel.updateFilter(
+                                SearchFilter(
+                                    city = selectedCity,
+                                    maxPrice = priceText.toIntOrNull(),
+                                ),
+                            )
+                        }) {
+                            Text(text = stringResource(id = R.string.apply_filters))
                         }
                     }
                     TabRow(selectedTabIndex = currentTab.ordinal) {

--- a/app/src/main/java/com/example/getfast/viewmodel/ListingViewModel.kt
+++ b/app/src/main/java/com/example/getfast/viewmodel/ListingViewModel.kt
@@ -3,6 +3,7 @@ package com.example.getfast.viewmodel
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.getfast.model.Listing
+import com.example.getfast.model.SearchFilter
 import com.example.getfast.repository.EbayRepository
 import java.text.DateFormat
 import java.util.Date
@@ -17,6 +18,9 @@ class ListingViewModel(
     private val _listings = MutableStateFlow<List<Listing>>(emptyList())
     val listings: StateFlow<List<Listing>> = _listings
 
+    private val _filter = MutableStateFlow(SearchFilter())
+    val filter: StateFlow<SearchFilter> = _filter
+
     private val formatter = DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.SHORT)
     private val _lastFetchTime = MutableStateFlow<String?>(null)
     val lastFetchTime: StateFlow<String?> = _lastFetchTime
@@ -30,11 +34,16 @@ class ListingViewModel(
     fun refreshListings() {
         viewModelScope.launch {
             _isRefreshing.value = true
-            _listings.value = repository.fetchLatestListings()
+            _listings.value = repository.fetchLatestListings(_filter.value)
                 .sortedByDescending { it.id.toLongOrNull() ?: Long.MIN_VALUE }
             _lastFetchTime.value = formatter.format(Date())
             _isRefreshing.value = false
         }
+    }
+
+    fun updateFilter(newFilter: SearchFilter) {
+        _filter.value = newFilter
+        refreshListings()
     }
 
     fun toggleFavorite(listing: Listing) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -13,4 +13,7 @@
     <string name="search_tab">Suche</string>
     <string name="copyright">\u00A9 2024 Christian Meyer</string>
     <string name="new_listing_channel">Neue Wohnungen</string>
+    <string name="city_label">Stadt</string>
+    <string name="max_price_label">Max. Preis (€)</string>
+    <string name="apply_filters">Filter anwenden</string>
 </resources>


### PR DESCRIPTION
## Summary
- add SearchFilter model with preset cities and optional max price
- allow repository and view model to request listings by selected city and price cap
- expose dropdown and price field in MainActivity to apply filters

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a08349257c8326977d5eccbf721d6c