### PR TITLE
Persist favorites across app restarts

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -50,6 +50,7 @@ dependencies {
 
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3")
     implementation("org.jsoup:jsoup:1.17.2")
+    implementation("androidx.datastore:datastore-preferences:1.0.0")
 
     debugImplementation("androidx.compose.ui:ui-tooling")
 

--- a/app/src/main/java/com/example/getfast/ui/MainActivity.kt
+++ b/app/src/main/java/com/example/getfast/ui/MainActivity.kt
@@ -29,6 +29,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.example.getfast.R
@@ -129,6 +130,7 @@ class MainActivity : ComponentActivity() {
                         modifier = Modifier
                             .fillMaxWidth()
                             .padding(horizontal = 8.dp, vertical = 4.dp),
+                        verticalAlignment = Alignment.CenterVertically,
                     ) {
                         FilterChip(
                             selected = !showFavoritesOnly,
@@ -136,6 +138,11 @@ class MainActivity : ComponentActivity() {
                             label = { Text(text = stringResource(id = R.string.all_tab)) },
                         )
                         Spacer(modifier = Modifier.weight(1f))
+                        if (showFavoritesOnly && favorites.isNotEmpty()) {
+                            TextButton(onClick = { viewModel.clearFavorites() }) {
+                                Text(text = stringResource(id = R.string.clear_favorites))
+                            }
+                        }
                         FilterChip(
                             selected = showFavoritesOnly,
                             onClick = { showFavoritesOnly = true },

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,6 +4,7 @@
     <string name="refresh">Aktualisieren</string>
     <string name="all_tab">Alle</string>
     <string name="favorites_tab">Favoriten</string>
+    <string name="clear_favorites">Favoriten löschen</string>
     <string name="favorite">Favorit</string>
     <string name="not_favorite">Nicht Favorit</string>
     <string name="open_in_app">In App öffnen</string>


### PR DESCRIPTION
## Summary
- store favorite listing ids in DataStore so they survive app restarts and can be cleared
- add button to remove all favorites and translate string
- include DataStore dependency

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a08591fb788326806b7fe07bd5af21