### PR TITLE
Fix ListingViewModel instantiation crash

### DIFF
--- a/app/src/main/java/com/example/getfast/viewmodel/ListingViewModel.kt
+++ b/app/src/main/java/com/example/getfast/viewmodel/ListingViewModel.kt
@@ -23,8 +23,9 @@ private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(na
 
 class ListingViewModel(
     application: Application,
-    private val repository: EbayRepository = EbayRepository(),
 ) : AndroidViewModel(application) {
+
+    private val repository = EbayRepository()
 
     private val dataStore = application.dataStore
     private val favoritesKey = stringSetPreferencesKey("favorites")


### PR DESCRIPTION
## Summary
- Ensure `ListingViewModel` uses an `Application`-only constructor and instantiates its repository internally to be compatible with default `ViewModelProvider`

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0898fbff88326a859f7145f1810f2