### PR TITLE
Implement pull-to-refresh and align filter inputs

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -46,6 +46,7 @@ dependencies {
     implementation("androidx.compose.ui:ui")
     implementation("androidx.compose.ui:ui-tooling-preview")
     implementation("androidx.compose.material3:material3")
+    implementation("androidx.compose.material:material")
     implementation("com.google.android.material:material:1.11.0")
 
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3")

--- a/app/src/main/java/com/example/getfast/ui/MainActivity.kt
+++ b/app/src/main/java/com/example/getfast/ui/MainActivity.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -75,6 +76,7 @@ class MainActivity : ComponentActivity() {
                 val lastFetch by viewModel.lastFetchTime.collectAsState()
                 val favorites by viewModel.favorites.collectAsState()
                 val filter by viewModel.filter.collectAsState()
+                val isRefreshing by viewModel.isRefreshing.collectAsState()
                 var showFavoritesOnly by remember { mutableStateOf(false) }
                 var currentTab by remember { mutableStateOf(ListingTab.OFFERS) }
                 var selectedCity by remember { mutableStateOf(filter.city) }
@@ -134,6 +136,7 @@ class MainActivity : ComponentActivity() {
                         modifier = Modifier
                             .fillMaxWidth()
                             .padding(horizontal = 8.dp, vertical = 4.dp),
+                        verticalAlignment = Alignment.CenterVertically,
                     ) {
                         var expanded by remember { mutableStateOf(false) }
                         ExposedDropdownMenuBox(
@@ -151,7 +154,9 @@ class MainActivity : ComponentActivity() {
                                 },
                                 modifier = Modifier
                                     .menuAnchor()
-                                    .fillMaxWidth(),
+                                    .fillMaxWidth()
+                                    .height(56.dp),
+                                singleLine = true,
                             )
                             DropdownMenu(
                                 expanded = expanded,
@@ -179,11 +184,16 @@ class MainActivity : ComponentActivity() {
                             value = priceText,
                             onValueChange = { priceText = it.filter { ch -> ch.isDigit() } },
                             label = { Text(text = stringResource(id = R.string.max_price_label)) },
-                            modifier = Modifier.weight(1f),
+                            singleLine = true,
+                            modifier = Modifier
+                                .weight(1f)
+                                .height(56.dp),
                         )
                         Spacer(modifier = Modifier.width(8.dp))
                         Button(
-                            modifier = Modifier.weight(1f),
+                            modifier = Modifier
+                                .weight(1f)
+                                .height(56.dp),
                             onClick = {
                                 viewModel.updateFilter(
                                     SearchFilter(
@@ -238,6 +248,8 @@ class MainActivity : ComponentActivity() {
                         onToggleFavorite = { viewModel.toggleFavorite(it) },
                         highlightedIds = highlightedIds,
                         blinkingIds = blinkingIds.value,
+                        isRefreshing = isRefreshing,
+                        onRefresh = { viewModel.refreshListings() },
                         modifier = Modifier.weight(1f),
                     )
                     Text(


### PR DESCRIPTION
## Summary
- add material dependency and pull-to-refresh support for listing list
- keep city, price and apply-filter inputs aligned with fixed heights
- memoize filtered listings and supply keys for better list performance

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a08d613d5c832699afea9d18c3fc3c