### PR TITLE
Use arrow to expand cards and auto dark theme

### DIFF
--- a/app/src/main/java/com/example/getfast/ui/MainActivity.kt
+++ b/app/src/main/java/com/example/getfast/ui/MainActivity.kt
@@ -7,6 +7,7 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
 import androidx.compose.foundation.background
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -68,8 +69,8 @@ class MainActivity : ComponentActivity() {
         }
         val notifier = Notifier(this)
         setContent {
-            val darkMode by viewModel.darkMode.collectAsState()
-            GetFastTheme(darkTheme = darkMode) {
+            val systemDark = isSystemInDarkTheme()
+            GetFastTheme(darkTheme = systemDark) {
                 val listings by viewModel.listings.collectAsState()
                 val lastFetch by viewModel.lastFetchTime.collectAsState()
                 val favorites by viewModel.favorites.collectAsState()
@@ -100,12 +101,10 @@ class MainActivity : ComponentActivity() {
                 if (showSettings) {
                     SettingsScreen(
                         filter = filter,
-                        darkMode = darkMode,
                         onApply = {
                             viewModel.updateFilter(it)
                             showSettings = false
                         },
-                        onDarkModeChange = { viewModel.setDarkMode(it) },
                         onBack = { showSettings = false },
                     )
                 } else {

--- a/app/src/main/java/com/example/getfast/ui/SettingsScreen.kt
+++ b/app/src/main/java/com/example/getfast/ui/SettingsScreen.kt
@@ -21,7 +21,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
@@ -41,9 +40,7 @@ import com.example.getfast.model.SearchFilter
 @Composable
 fun SettingsScreen(
     filter: SearchFilter,
-    darkMode: Boolean,
     onApply: (SearchFilter) -> Unit,
-    onDarkModeChange: (Boolean) -> Unit,
     onBack: () -> Unit,
 ) {
     var selectedCity by remember { mutableStateOf(filter.city) }
@@ -117,12 +114,6 @@ fun SettingsScreen(
                 },
                 label = { Text(text = stringResource(id = R.string.source_immoscout)) }
             )
-        }
-        Spacer(modifier = Modifier.height(16.dp))
-        Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.fillMaxWidth()) {
-            Text(text = stringResource(id = R.string.dark_mode))
-            Spacer(modifier = Modifier.weight(1f))
-            Switch(checked = darkMode, onCheckedChange = onDarkModeChange)
         }
         Spacer(modifier = Modifier.height(16.dp))
         Button(

--- a/app/src/main/java/com/example/getfast/ui/components/ListingComponents.kt
+++ b/app/src/main/java/com/example/getfast/ui/components/ListingComponents.kt
@@ -4,6 +4,7 @@ import android.content.Intent
 import android.net.Uri
 import androidx.compose.animation.animateColor
 import androidx.compose.animation.animateContentSize
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -26,6 +27,7 @@ import androidx.compose.animation.core.tween
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material.icons.outlined.FavoriteBorder
 import androidx.compose.material.pullrefresh.PullRefreshIndicator
 import androidx.compose.material.pullrefresh.pullRefresh
@@ -34,6 +36,7 @@ import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.IconToggleButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -49,6 +52,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontStyle
@@ -214,13 +218,6 @@ fun ListingCard(
                 },
                 onDragStopped = { dragAmount = 0f },
             )
-            .draggable(
-                orientation = Orientation.Vertical,
-                state = rememberDraggableState { delta ->
-                    if (delta > 20) expanded = true
-                    if (delta < -20) expanded = false
-                },
-            )
             .clickable(onClick = onClick)
             .animateContentSize(),
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
@@ -234,6 +231,14 @@ fun ListingCard(
                     color = MaterialTheme.colorScheme.primary,
                     modifier = Modifier.weight(1f)
                 )
+                val rotation by animateFloatAsState(if (expanded) 180f else 0f, label = "rotation")
+                IconButton(onClick = { expanded = !expanded }) {
+                    Icon(
+                        imageVector = Icons.Filled.ExpandMore,
+                        contentDescription = if (expanded) stringResource(id = R.string.collapse_card) else stringResource(id = R.string.expand_card),
+                        modifier = Modifier.rotate(rotation)
+                    )
+                }
                 IconToggleButton(checked = isFavorite, onCheckedChange = { onToggleFavorite(listing) }) {
                     if (isFavorite) {
                         Icon(

--- a/app/src/main/java/com/example/getfast/viewmodel/ListingViewModel.kt
+++ b/app/src/main/java/com/example/getfast/viewmodel/ListingViewModel.kt
@@ -5,7 +5,6 @@ import android.content.Context
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
-import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.stringSetPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import androidx.lifecycle.AndroidViewModel
@@ -34,7 +33,6 @@ class ListingViewModel(
     private val dataStore = application.dataStore
     private val favoritesKey = stringSetPreferencesKey("favorites")
     private val archivedKey = stringSetPreferencesKey("archived")
-    private val darkModeKey = booleanPreferencesKey("dark_mode")
 
     private val _listings = MutableStateFlow<List<Listing>>(emptyList())
     val listings: StateFlow<List<Listing>> = _listings
@@ -52,8 +50,6 @@ class ListingViewModel(
     private val _archived = MutableStateFlow<Set<String>>(emptySet())
     val archived: StateFlow<Set<String>> = _archived
 
-    private val _darkMode = MutableStateFlow(false)
-    val darkMode: StateFlow<Boolean> = _darkMode
 
     private val _isRefreshing = MutableStateFlow(false)
     val isRefreshing: StateFlow<Boolean> = _isRefreshing
@@ -63,7 +59,6 @@ class ListingViewModel(
             val prefs = dataStore.data.first()
             _favorites.value = prefs[favoritesKey] ?: emptySet()
             _archived.value = prefs[archivedKey] ?: emptySet()
-            _darkMode.value = prefs[darkModeKey] ?: false
         }
     }
 
@@ -103,12 +98,6 @@ class ListingViewModel(
         }
     }
 
-    fun setDarkMode(enabled: Boolean) {
-        _darkMode.value = enabled
-        viewModelScope.launch {
-            dataStore.edit { it[darkModeKey] = enabled }
-        }
-    }
 
     /**
      * Markiert ein Listing als archiviert und speichert den Zustand.

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -24,5 +24,6 @@
     <string name="back">Zurück</string>
     <string name="source_kleinanzeigen">Kleinanzeigen</string>
     <string name="source_immoscout">ImmoScout</string>
-    <string name="dark_mode">Dunkler Modus</string>
+    <string name="expand_card">Anzeige vergrößern</string>
+    <string name="collapse_card">Anzeige verkleinern</string>
 </resources>


### PR DESCRIPTION
## Summary
- replace vertical drag expansion with explicit arrow button
- automatically follow system dark theme and drop manual switch

## Testing
- `gradle build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a09829be8483269edd18894e1c6d97