### PR TITLE
Add additional housing listing sources

### DIFF
--- a/app/src/main/java/com/example/getfast/model/SearchFilter.kt
+++ b/app/src/main/java/com/example/getfast/model/SearchFilter.kt
@@ -29,4 +29,7 @@ enum class City(val displayName: String, val urlPath: String) {
 enum class ListingSource {
     KLEINANZEIGEN,
     IMMOSCOUT,
+    IMMONET,
+    IMMOWELT,
+    WOHNUNGSBOERSE,
 }

--- a/app/src/main/java/com/example/getfast/repository/ListingParser.kt
+++ b/app/src/main/java/com/example/getfast/repository/ListingParser.kt
@@ -53,6 +53,111 @@ class ListingParser {
     }
 
     /**
+     * Parst ein Immonet-Dokument in Listings.
+     */
+    fun parseImmonet(document: Document): List<Listing> {
+        return document.select("article.immonet-entry").mapNotNull { element ->
+            val id = element.attr("data-id")
+            val link = element.selectFirst("a.immonet-link")
+            val href = link?.attr("href")
+            val title = link?.text()
+            if (id.isBlank() || href == null || title.isNullOrBlank()) {
+                return@mapNotNull null
+            }
+            val price = element.selectFirst(".immonet-price")?.text()?.trim() ?: ""
+            val address = element.selectFirst(".immonet-address")?.text()?.trim() ?: ""
+            val parts = address.split(",")
+            val district = parts.getOrNull(0)?.trim() ?: ""
+            val city = parts.getOrNull(1)?.trim() ?: ""
+            val summary = element.selectFirst(".immonet-desc")?.text()?.trim() ?: ""
+            val image = element.selectFirst("img")?.attr("src")
+            val images = if (image.isNullOrBlank()) emptyList() else listOf(image)
+            Listing(
+                id = id,
+                title = title,
+                url = "https://www.immonet.de$href",
+                date = "",
+                district = district,
+                city = city,
+                price = price,
+                summary = summary,
+                imageUrls = images,
+                isSearch = false,
+            )
+        }
+    }
+
+    /**
+     * Parst ein Immowelt-Dokument in Listings.
+     */
+    fun parseImmowelt(document: Document): List<Listing> {
+        return document.select("article.immowelt-entry").mapNotNull { element ->
+            val id = element.attr("data-id")
+            val link = element.selectFirst("a.immowelt-link")
+            val href = link?.attr("href")
+            val title = link?.text()
+            if (id.isBlank() || href == null || title.isNullOrBlank()) {
+                return@mapNotNull null
+            }
+            val price = element.selectFirst(".immowelt-price")?.text()?.trim() ?: ""
+            val address = element.selectFirst(".immowelt-address")?.text()?.trim() ?: ""
+            val parts = address.split(",")
+            val district = parts.getOrNull(0)?.trim() ?: ""
+            val city = parts.getOrNull(1)?.trim() ?: ""
+            val summary = element.selectFirst(".immowelt-desc")?.text()?.trim() ?: ""
+            val image = element.selectFirst("img")?.attr("src")
+            val images = if (image.isNullOrBlank()) emptyList() else listOf(image)
+            Listing(
+                id = id,
+                title = title,
+                url = "https://www.immowelt.de$href",
+                date = "",
+                district = district,
+                city = city,
+                price = price,
+                summary = summary,
+                imageUrls = images,
+                isSearch = false,
+            )
+        }
+    }
+
+    /**
+     * Parst ein Wohnungsboerse-Dokument in Listings.
+     */
+    fun parseWohnungsboerse(document: Document): List<Listing> {
+        return document.select("article.wohnungsboerse-entry").mapNotNull { element ->
+            val id = element.attr("data-id")
+            val link = element.selectFirst("a.wohnungsboerse-link")
+            val href = link?.attr("href")
+            val title = link?.text()
+            if (id.isBlank() || href == null || title.isNullOrBlank()) {
+                return@mapNotNull null
+            }
+            val price = element.selectFirst(".wohnungsboerse-price")?.text()?.trim() ?: ""
+            val address = element.selectFirst(".wohnungsboerse-address")?.text()?.trim() ?: ""
+            val parts = address.split(",")
+            val district = parts.getOrNull(0)?.trim() ?: ""
+            val city = parts.getOrNull(1)?.trim() ?: ""
+            val summary = element.selectFirst(".wohnungsboerse-desc")?.text()?.trim() ?: ""
+            val image = element.selectFirst("img")?.attr("src")
+            val images = if (image.isNullOrBlank()) emptyList() else listOf(image)
+            Listing(
+                id = id,
+                title = title,
+                url = "https://www.wohnungsboerse.net$href",
+                date = "",
+                district = district,
+                city = city,
+                price = price,
+                summary = summary,
+                imageUrls = images,
+                isSearch = false,
+            )
+        }
+    }
+
+    /**
      * Wandelt ein einzelnes HTML-Element in ein Listing-Objekt um.
      */
     private fun parseListing(element: Element): Listing? {

--- a/app/src/main/java/com/example/getfast/repository/ListingRepository.kt
+++ b/app/src/main/java/com/example/getfast/repository/ListingRepository.kt
@@ -26,6 +26,15 @@ class ListingRepository(
         if (ListingSource.IMMOSCOUT in filter.sources) {
             results += fetchImmoscout(filter)
         }
+        if (ListingSource.IMMONET in filter.sources) {
+            results += fetchImmonet(filter)
+        }
+        if (ListingSource.IMMOWELT in filter.sources) {
+            results += fetchImmowelt(filter)
+        }
+        if (ListingSource.WOHNUNGSBOERSE in filter.sources) {
+            results += fetchWohnungsboerse(filter)
+        }
         val maxPrice = filter.maxPrice
         return if (maxPrice != null) {
             results.filter { listing ->
@@ -53,6 +62,36 @@ class ListingRepository(
         return try {
             val doc = fetcher.fetch(url)
             parser.parseImmoscout(doc)
+        } catch (e: Exception) {
+            emptyList()
+        }
+    }
+
+    private suspend fun fetchImmonet(filter: SearchFilter): List<Listing> {
+        val url = "https://www.immonet.de/${filter.city.displayName}"
+        return try {
+            val doc = fetcher.fetch(url)
+            parser.parseImmonet(doc)
+        } catch (e: Exception) {
+            emptyList()
+        }
+    }
+
+    private suspend fun fetchImmowelt(filter: SearchFilter): List<Listing> {
+        val url = "https://www.immowelt.de/${filter.city.displayName}"
+        return try {
+            val doc = fetcher.fetch(url)
+            parser.parseImmowelt(doc)
+        } catch (e: Exception) {
+            emptyList()
+        }
+    }
+
+    private suspend fun fetchWohnungsboerse(filter: SearchFilter): List<Listing> {
+        val url = "https://www.wohnungsboerse.net/${filter.city.displayName}"
+        return try {
+            val doc = fetcher.fetch(url)
+            parser.parseWohnungsboerse(doc)
         } catch (e: Exception) {
             emptyList()
         }

--- a/app/src/main/java/com/example/getfast/ui/SettingsScreen.kt
+++ b/app/src/main/java/com/example/getfast/ui/SettingsScreen.kt
@@ -115,6 +115,35 @@ fun SettingsScreen(
                 },
                 label = { Text(text = stringResource(id = R.string.source_immoscout)) }
             )
+            Spacer(modifier = Modifier.width(8.dp))
+            FilterChip(
+                selected = ListingSource.IMMONET in sources,
+                onClick = {
+                    if (ListingSource.IMMONET in sources) sources.remove(ListingSource.IMMONET)
+                    else sources.add(ListingSource.IMMONET)
+                },
+                label = { Text(text = stringResource(id = R.string.source_immonet)) }
+            )
+        }
+        Spacer(modifier = Modifier.height(8.dp))
+        Row(modifier = Modifier.fillMaxWidth()) {
+            FilterChip(
+                selected = ListingSource.IMMOWELT in sources,
+                onClick = {
+                    if (ListingSource.IMMOWELT in sources) sources.remove(ListingSource.IMMOWELT)
+                    else sources.add(ListingSource.IMMOWELT)
+                },
+                label = { Text(text = stringResource(id = R.string.source_immowelt)) }
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            FilterChip(
+                selected = ListingSource.WOHNUNGSBOERSE in sources,
+                onClick = {
+                    if (ListingSource.WOHNUNGSBOERSE in sources) sources.remove(ListingSource.WOHNUNGSBOERSE)
+                    else sources.add(ListingSource.WOHNUNGSBOERSE)
+                },
+                label = { Text(text = stringResource(id = R.string.source_wohnungsboerse)) }
+            )
         }
         Spacer(modifier = Modifier.height(16.dp))
         Button(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -24,6 +24,9 @@
     <string name="back">Zurück</string>
     <string name="source_kleinanzeigen">Kleinanzeigen</string>
     <string name="source_immoscout">ImmoScout</string>
+    <string name="source_immonet">Immonet</string>
+    <string name="source_immowelt">Immowelt</string>
+    <string name="source_wohnungsboerse">Wohnungsboerse.net</string>
     <string name="expand_card">Anzeige vergrößern</string>
     <string name="collapse_card">Anzeige verkleinern</string>
 </resources>

--- a/app/src/test/java/com/example/getfast/ListingParserTest.kt
+++ b/app/src/test/java/com/example/getfast/ListingParserTest.kt
@@ -37,6 +37,42 @@ class ListingParserTest {
         </body></html>
     """.trimIndent()
 
+    private val immonetHtml = """
+        <html><body>
+        <article class='immonet-entry' data-id='20'>
+          <a href='/expose/20' class='immonet-link'>Net 1</a>
+          <div class='immonet-price'>300 €</div>
+          <div class='immonet-address'>Bezirk, Stadt</div>
+          <div class='immonet-desc'>Beschreibung.</div>
+          <img src='img.jpg'/>
+        </article>
+        </body></html>
+    """.trimIndent()
+
+    private val immoweltHtml = """
+        <html><body>
+        <article class='immowelt-entry' data-id='30'>
+          <a href='/expose/30' class='immowelt-link'>Welt 1</a>
+          <div class='immowelt-price'>400 €</div>
+          <div class='immowelt-address'>Bezirk, Stadt</div>
+          <div class='immowelt-desc'>Beschreibung.</div>
+          <img src='img.jpg'/>
+        </article>
+        </body></html>
+    """.trimIndent()
+
+    private val wohnungsboerseHtml = """
+        <html><body>
+        <article class='wohnungsboerse-entry' data-id='40'>
+          <a href='/expose/40' class='wohnungsboerse-link'>Boerse 1</a>
+          <div class='wohnungsboerse-price'>500 €</div>
+          <div class='wohnungsboerse-address'>Bezirk, Stadt</div>
+          <div class='wohnungsboerse-desc'>Beschreibung.</div>
+          <img src='img.jpg'/>
+        </article>
+        </body></html>
+    """.trimIndent()
+
     @Test
     fun parse_returnsAllListings() {
         val parser = ListingParser()
@@ -53,5 +89,32 @@ class ListingParserTest {
         val listings = parser.parseImmoscout(doc)
         assertEquals(1, listings.size)
         assertEquals("Immo 1", listings[0].title)
+    }
+
+    @Test
+    fun parseImmonet_returnsListings() {
+        val parser = ListingParser()
+        val doc = Jsoup.parse(immonetHtml)
+        val listings = parser.parseImmonet(doc)
+        assertEquals(1, listings.size)
+        assertEquals("Net 1", listings[0].title)
+    }
+
+    @Test
+    fun parseImmowelt_returnsListings() {
+        val parser = ListingParser()
+        val doc = Jsoup.parse(immoweltHtml)
+        val listings = parser.parseImmowelt(doc)
+        assertEquals(1, listings.size)
+        assertEquals("Welt 1", listings[0].title)
+    }
+
+    @Test
+    fun parseWohnungsboerse_returnsListings() {
+        val parser = ListingParser()
+        val doc = Jsoup.parse(wohnungsboerseHtml)
+        val listings = parser.parseWohnungsboerse(doc)
+        assertEquals(1, listings.size)
+        assertEquals("Boerse 1", listings[0].title)
     }
 }

--- a/app/src/test/java/com/example/getfast/ListingRepositoryTest.kt
+++ b/app/src/test/java/com/example/getfast/ListingRepositoryTest.kt
@@ -45,6 +45,39 @@ class ListingRepositoryTest {
         </body></html>
     """.trimIndent()
 
+    private val immonetHtml = """
+        <html><body>
+        <article class='immonet-entry' data-id='20'>
+          <a href='/expose/20' class='immonet-link'>Net 1</a>
+          <div class='immonet-price'>300 €</div>
+          <div class='immonet-address'>Bezirk, Stadt</div>
+          <div class='immonet-desc'>Beschreibung.</div>
+        </article>
+        </body></html>
+    """.trimIndent()
+
+    private val immoweltHtml = """
+        <html><body>
+        <article class='immowelt-entry' data-id='30'>
+          <a href='/expose/30' class='immowelt-link'>Welt 1</a>
+          <div class='immowelt-price'>400 €</div>
+          <div class='immowelt-address'>Bezirk, Stadt</div>
+          <div class='immowelt-desc'>Beschreibung.</div>
+        </article>
+        </body></html>
+    """.trimIndent()
+
+    private val wohnungsboerseHtml = """
+        <html><body>
+        <article class='wohnungsboerse-entry' data-id='40'>
+          <a href='/expose/40' class='wohnungsboerse-link'>Boerse 1</a>
+          <div class='wohnungsboerse-price'>500 €</div>
+          <div class='wohnungsboerse-address'>Bezirk, Stadt</div>
+          <div class='wohnungsboerse-desc'>Beschreibung.</div>
+        </article>
+        </body></html>
+    """.trimIndent()
+
     @Test
     fun fetchLatestListings_filtersByMaxPrice() = runBlocking {
         val repo = ListingRepository(fetcher = FakeFetcher(html))
@@ -60,5 +93,32 @@ class ListingRepositoryTest {
         val listings = repo.fetchLatestListings(filter)
         assertEquals(1, listings.size)
         assertEquals("Immo 1", listings[0].title)
+    }
+
+    @Test
+    fun fetchLatestListings_returnsImmonetListings() = runBlocking {
+        val repo = ListingRepository(fetcher = FakeFetcher(immonetHtml))
+        val filter = SearchFilter(sources = setOf(ListingSource.IMMONET))
+        val listings = repo.fetchLatestListings(filter)
+        assertEquals(1, listings.size)
+        assertEquals("Net 1", listings[0].title)
+    }
+
+    @Test
+    fun fetchLatestListings_returnsImmoweltListings() = runBlocking {
+        val repo = ListingRepository(fetcher = FakeFetcher(immoweltHtml))
+        val filter = SearchFilter(sources = setOf(ListingSource.IMMOWELT))
+        val listings = repo.fetchLatestListings(filter)
+        assertEquals(1, listings.size)
+        assertEquals("Welt 1", listings[0].title)
+    }
+
+    @Test
+    fun fetchLatestListings_returnsWohnungsboerseListings() = runBlocking {
+        val repo = ListingRepository(fetcher = FakeFetcher(wohnungsboerseHtml))
+        val filter = SearchFilter(sources = setOf(ListingSource.WOHNUNGSBOERSE))
+        val listings = repo.fetchLatestListings(filter)
+        assertEquals(1, listings.size)
+        assertEquals("Boerse 1", listings[0].title)
     }
 }


### PR DESCRIPTION
## Summary
- extend listing source options with Immonet, Immowelt and Wohnungsboerse.net
- fetch and parse listings from the new sources
- expose new sources in settings and add unit tests

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a09b2ac4ec8326b46a491dc4fe06a0