### PR TITLE
Enable all providers in listing filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GetFast
 
-Android app using MVVM architecture to monitor eBay Kleinanzeigen for new housing listings. The app fetches listings from a configurable search URL, displays them in a list and triggers a local push notification for new entries.
+Android app using MVVM architecture to monitor multiple housing listing providers (eBay Kleinanzeigen, ImmoScout, Immonet, Immowelt, Wohnungsboerse.net) for new housing listings. By default the search pulls results from all providers, but sources can be toggled in Settings. The app fetches listings from a configurable search URL, displays them in a list and triggers a local push notification for new entries.
 
 ## Build & Run
 

--- a/app/src/main/java/com/example/getfast/model/SearchFilter.kt
+++ b/app/src/main/java/com/example/getfast/model/SearchFilter.kt
@@ -10,7 +10,7 @@ package com.example.getfast.model
 data class SearchFilter(
     val city: City = City.BERLIN,
     val maxPrice: Int? = null,
-    val sources: Set<ListingSource> = setOf(ListingSource.KLEINANZEIGEN),
+    val sources: Set<ListingSource> = ListingSource.values().toSet(),
 )
 
 /**


### PR DESCRIPTION
## Summary
- Load listings from all providers by default
- Document multi-provider support and default behaviour

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a09d9cbe8883269178fe7c9e60d58e