### PR TITLE
Fix listing parsers for major real-estate sites

### DIFF
--- a/app/src/main/java/com/example/getfast/repository/ListingParser.kt
+++ b/app/src/main/java/com/example/getfast/repository/ListingParser.kt
@@ -21,21 +21,22 @@ class ListingParser {
      * Parst ein Immoscout-Dokument in Listings.
      */
     fun parseImmoscout(document: Document): List<Listing> {
-        return document.select("article.result-list-entry").mapNotNull { element ->
+        return document.select("li.result-list__listing[data-obid]").mapNotNull { element ->
             val id = element.attr("data-obid")
             val link = element.selectFirst("a.result-list-entry__brand-title-container")
             val href = link?.attr("href")
-            val title = link?.text()
+            val title = link?.text()?.trim()
             if (id.isBlank() || href == null || title.isNullOrBlank()) {
                 return@mapNotNull null
             }
-            val price = element.selectFirst(".result-list-entry__primary-criterion")?.text()?.trim() ?: ""
+            val price = element.selectFirst(".result-list-entry__primary-criterion dd")?.text()?.trim() ?: ""
             val address = element.selectFirst(".result-list-entry__address")?.text()?.trim() ?: ""
             val parts = address.split(",")
             val district = parts.getOrNull(0)?.trim() ?: ""
             val city = parts.getOrNull(1)?.trim() ?: ""
             val summary = element.selectFirst(".result-list-entry__description")?.text()?.trim() ?: ""
-            val image = element.selectFirst("img")?.attr("src")
+            val image = element.selectFirst("img[data-src]")?.attr("data-src")
+                ?: element.selectFirst("img[src]")?.attr("src")
             val images = if (image.isNullOrBlank()) emptyList() else listOf(image)
             Listing(
                 id = id,
@@ -56,26 +57,27 @@ class ListingParser {
      * Parst ein Immonet-Dokument in Listings.
      */
     fun parseImmonet(document: Document): List<Listing> {
-        return document.select("article.immonet-entry").mapNotNull { element ->
+        return document.select("article.search-list-entry[data-id]").mapNotNull { element ->
             val id = element.attr("data-id")
-            val link = element.selectFirst("a.immonet-link")
+            val link = element.selectFirst("a[href*='/angebot/']")
             val href = link?.attr("href")
-            val title = link?.text()
+            val title = link?.text()?.trim()
             if (id.isBlank() || href == null || title.isNullOrBlank()) {
                 return@mapNotNull null
             }
-            val price = element.selectFirst(".immonet-price")?.text()?.trim() ?: ""
-            val address = element.selectFirst(".immonet-address")?.text()?.trim() ?: ""
+            val price = element.selectFirst(".result-item-price, .search-list-entry__primary-criterion")?.text()?.trim() ?: ""
+            val address = element.selectFirst(".result-item-address, .search-list-entry__address")?.text()?.trim() ?: ""
             val parts = address.split(",")
             val district = parts.getOrNull(0)?.trim() ?: ""
             val city = parts.getOrNull(1)?.trim() ?: ""
-            val summary = element.selectFirst(".immonet-desc")?.text()?.trim() ?: ""
-            val image = element.selectFirst("img")?.attr("src")
+            val summary = element.selectFirst(".result-item-description, .search-list-entry__description")?.text()?.trim() ?: ""
+            val image = element.selectFirst("img[data-src]")?.attr("data-src")
+                ?: element.selectFirst("img[src]")?.attr("src")
             val images = if (image.isNullOrBlank()) emptyList() else listOf(image)
             Listing(
                 id = id,
                 title = title,
-                url = "https://www.immonet.de$href",
+                url = if (href.startsWith("http")) href else "https://www.immonet.de$href",
                 date = "",
                 district = district,
                 city = city,
@@ -91,26 +93,27 @@ class ListingParser {
      * Parst ein Immowelt-Dokument in Listings.
      */
     fun parseImmowelt(document: Document): List<Listing> {
-        return document.select("article.immowelt-entry").mapNotNull { element ->
+        return document.select("div.EstateItem[data-id]").mapNotNull { element ->
             val id = element.attr("data-id")
-            val link = element.selectFirst("a.immowelt-link")
+            val link = element.selectFirst("a[href*='/expose/']")
             val href = link?.attr("href")
-            val title = link?.text()
+            val title = link?.text()?.trim()
             if (id.isBlank() || href == null || title.isNullOrBlank()) {
                 return@mapNotNull null
             }
-            val price = element.selectFirst(".immowelt-price")?.text()?.trim() ?: ""
-            val address = element.selectFirst(".immowelt-address")?.text()?.trim() ?: ""
+            val price = element.selectFirst(".EstateItem-price, .price")?.text()?.trim() ?: ""
+            val address = element.selectFirst(".EstateItem-address, .address")?.text()?.trim() ?: ""
             val parts = address.split(",")
             val district = parts.getOrNull(0)?.trim() ?: ""
             val city = parts.getOrNull(1)?.trim() ?: ""
-            val summary = element.selectFirst(".immowelt-desc")?.text()?.trim() ?: ""
-            val image = element.selectFirst("img")?.attr("src")
+            val summary = element.selectFirst(".EstateItem-description, .description")?.text()?.trim() ?: ""
+            val image = element.selectFirst("img[data-src]")?.attr("data-src")
+                ?: element.selectFirst("img[src]")?.attr("src")
             val images = if (image.isNullOrBlank()) emptyList() else listOf(image)
             Listing(
                 id = id,
                 title = title,
-                url = "https://www.immowelt.de$href",
+                url = if (href.startsWith("http")) href else "https://www.immowelt.de$href",
                 date = "",
                 district = district,
                 city = city,
@@ -126,21 +129,22 @@ class ListingParser {
      * Parst ein Wohnungsboerse-Dokument in Listings.
      */
     fun parseWohnungsboerse(document: Document): List<Listing> {
-        return document.select("article.wohnungsboerse-entry").mapNotNull { element ->
+        return document.select("div.inserate-result[data-id]").mapNotNull { element ->
             val id = element.attr("data-id")
-            val link = element.selectFirst("a.wohnungsboerse-link")
+            val link = element.selectFirst("a.ad-list-item")
             val href = link?.attr("href")
-            val title = link?.text()
+            val title = link?.selectFirst("h2")?.text()?.trim()
             if (id.isBlank() || href == null || title.isNullOrBlank()) {
                 return@mapNotNull null
             }
-            val price = element.selectFirst(".wohnungsboerse-price")?.text()?.trim() ?: ""
-            val address = element.selectFirst(".wohnungsboerse-address")?.text()?.trim() ?: ""
+            val price = link.selectFirst(".mietpreis")?.text()?.trim() ?: ""
+            val address = link.selectFirst(".adresse")?.text()?.trim() ?: ""
             val parts = address.split(",")
             val district = parts.getOrNull(0)?.trim() ?: ""
             val city = parts.getOrNull(1)?.trim() ?: ""
-            val summary = element.selectFirst(".wohnungsboerse-desc")?.text()?.trim() ?: ""
-            val image = element.selectFirst("img")?.attr("src")
+            val summary = link.selectFirst(".beschreibung")?.text()?.trim() ?: ""
+            val image = link.selectFirst("img[data-src]")?.attr("data-src")
+                ?: link.selectFirst("img[src]")?.attr("src")
             val images = if (image.isNullOrBlank()) emptyList() else listOf(image)
             Listing(
                 id = id,

--- a/app/src/test/java/com/example/getfast/ListingParserTest.kt
+++ b/app/src/test/java/com/example/getfast/ListingParserTest.kt
@@ -27,49 +27,51 @@ class ListingParserTest {
 
     private val immoscoutHtml = """
         <html><body>
-        <article class='result-list-entry' data-obid='10'>
+        <li class='result-list__listing' data-obid='10'>
           <a href='/expose/10' class='result-list-entry__brand-title-container'>Immo 1</a>
-          <div class='result-list-entry__primary-criterion'>200 €</div>
+          <div class='result-list-entry__primary-criterion'><dd>200 €</dd></div>
           <div class='result-list-entry__address'>Bezirk, Stadt</div>
           <div class='result-list-entry__description'>Beschreibung.</div>
-          <img src='img.jpg'/>
-        </article>
+          <img data-src='img.jpg'/>
+        </li>
         </body></html>
     """.trimIndent()
 
     private val immonetHtml = """
         <html><body>
-        <article class='immonet-entry' data-id='20'>
-          <a href='/expose/20' class='immonet-link'>Net 1</a>
-          <div class='immonet-price'>300 €</div>
-          <div class='immonet-address'>Bezirk, Stadt</div>
-          <div class='immonet-desc'>Beschreibung.</div>
-          <img src='img.jpg'/>
+        <article class='search-list-entry' data-id='20'>
+          <a href='/angebot/20' class='result-item-title'>Net 1</a>
+          <div class='result-item-price'>300 €</div>
+          <div class='result-item-address'>Bezirk, Stadt</div>
+          <div class='result-item-description'>Beschreibung.</div>
+          <img data-src='img.jpg'/>
         </article>
         </body></html>
     """.trimIndent()
 
     private val immoweltHtml = """
         <html><body>
-        <article class='immowelt-entry' data-id='30'>
-          <a href='/expose/30' class='immowelt-link'>Welt 1</a>
-          <div class='immowelt-price'>400 €</div>
-          <div class='immowelt-address'>Bezirk, Stadt</div>
-          <div class='immowelt-desc'>Beschreibung.</div>
+        <div class='EstateItem' data-id='30'>
+          <a href='/expose/30' class='EstateItem-title'>Welt 1</a>
+          <div class='EstateItem-price'>400 €</div>
+          <div class='EstateItem-address'>Bezirk, Stadt</div>
+          <div class='EstateItem-description'>Beschreibung.</div>
           <img src='img.jpg'/>
-        </article>
+        </div>
         </body></html>
     """.trimIndent()
 
     private val wohnungsboerseHtml = """
         <html><body>
-        <article class='wohnungsboerse-entry' data-id='40'>
-          <a href='/expose/40' class='wohnungsboerse-link'>Boerse 1</a>
-          <div class='wohnungsboerse-price'>500 €</div>
-          <div class='wohnungsboerse-address'>Bezirk, Stadt</div>
-          <div class='wohnungsboerse-desc'>Beschreibung.</div>
-          <img src='img.jpg'/>
-        </article>
+        <div class='inserate-result' data-id='40'>
+          <a href='/detail/40' class='ad-list-item'>
+            <h2>Boerse 1</h2>
+            <p class='mietpreis'>500 €</p>
+            <p class='adresse'>Bezirk, Stadt</p>
+            <p class='beschreibung'>Beschreibung.</p>
+            <img src='img.jpg'/>
+          </a>
+        </div>
         </body></html>
     """.trimIndent()
 

--- a/app/src/test/java/com/example/getfast/ListingRepositoryTest.kt
+++ b/app/src/test/java/com/example/getfast/ListingRepositoryTest.kt
@@ -36,45 +36,47 @@ class ListingRepositoryTest {
 
     private val immoscoutHtml = """
         <html><body>
-        <article class='result-list-entry' data-obid='10'>
+        <li class='result-list__listing' data-obid='10'>
           <a href='/expose/10' class='result-list-entry__brand-title-container'>Immo 1</a>
-          <div class='result-list-entry__primary-criterion'>200 €</div>
+          <div class='result-list-entry__primary-criterion'><dd>200 €</dd></div>
           <div class='result-list-entry__address'>Bezirk, Stadt</div>
           <div class='result-list-entry__description'>Beschreibung.</div>
-        </article>
+        </li>
         </body></html>
     """.trimIndent()
 
     private val immonetHtml = """
         <html><body>
-        <article class='immonet-entry' data-id='20'>
-          <a href='/expose/20' class='immonet-link'>Net 1</a>
-          <div class='immonet-price'>300 €</div>
-          <div class='immonet-address'>Bezirk, Stadt</div>
-          <div class='immonet-desc'>Beschreibung.</div>
+        <article class='search-list-entry' data-id='20'>
+          <a href='/angebot/20' class='result-item-title'>Net 1</a>
+          <div class='result-item-price'>300 €</div>
+          <div class='result-item-address'>Bezirk, Stadt</div>
+          <div class='result-item-description'>Beschreibung.</div>
         </article>
         </body></html>
     """.trimIndent()
 
     private val immoweltHtml = """
         <html><body>
-        <article class='immowelt-entry' data-id='30'>
-          <a href='/expose/30' class='immowelt-link'>Welt 1</a>
-          <div class='immowelt-price'>400 €</div>
-          <div class='immowelt-address'>Bezirk, Stadt</div>
-          <div class='immowelt-desc'>Beschreibung.</div>
-        </article>
+        <div class='EstateItem' data-id='30'>
+          <a href='/expose/30' class='EstateItem-title'>Welt 1</a>
+          <div class='EstateItem-price'>400 €</div>
+          <div class='EstateItem-address'>Bezirk, Stadt</div>
+          <div class='EstateItem-description'>Beschreibung.</div>
+        </div>
         </body></html>
     """.trimIndent()
 
     private val wohnungsboerseHtml = """
         <html><body>
-        <article class='wohnungsboerse-entry' data-id='40'>
-          <a href='/expose/40' class='wohnungsboerse-link'>Boerse 1</a>
-          <div class='wohnungsboerse-price'>500 €</div>
-          <div class='wohnungsboerse-address'>Bezirk, Stadt</div>
-          <div class='wohnungsboerse-desc'>Beschreibung.</div>
-        </article>
+        <div class='inserate-result' data-id='40'>
+          <a href='/detail/40' class='ad-list-item'>
+            <h2>Boerse 1</h2>
+            <p class='mietpreis'>500 €</p>
+            <p class='adresse'>Bezirk, Stadt</p>
+            <p class='beschreibung'>Beschreibung.</p>
+          </a>
+        </div>
         </body></html>
     """.trimIndent()
 


### PR DESCRIPTION
## Summary
- align Immoscout parser with real `result-list__listing` DOM structure
- update Immonet, Immowelt, and Wohnungsboerse parsers to extract price, address, summary, and images
- adjust parser tests to use realistic HTML samples

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0a5ca80108326be889654d2bac10a