### PR TITLE
feat: extend city search filter with provider paths

### DIFF
--- a/app/src/main/java/com/example/getfast/model/SearchFilter.kt
+++ b/app/src/main/java/com/example/getfast/model/SearchFilter.kt
@@ -17,13 +17,86 @@ data class SearchFilter(
 )
 
 /**
- * Limited set of supported cities and their respective URL paths on Kleinanzeigen.
- * The structure makes it easy to extend with additional cities in the future.
+ * Supported cities and the provider specific URL paths or identifiers
+ * used to build search URLs.
  */
-enum class City(val displayName: String, val urlPath: String) {
-    BERLIN("Berlin", "berlin/c203l3331"),
-    HAMBURG("Hamburg", "hamburg/c203l9409"),
-    MUNICH("München", "muenchen/c203l6436"),
+enum class City(
+    val displayName: String,
+    private val providerPaths: Map<ListingSource, String>
+) {
+    BERLIN(
+        "Berlin",
+        mapOf(
+            ListingSource.KLEINANZEIGEN to "berlin/c203l3331",
+            ListingSource.IMMOSCOUT to "Berlin",
+            ListingSource.IMMONET to "berlin",
+            ListingSource.IMMOWELT to "berlin",
+            ListingSource.WOHNUNGSBOERSE to "berlin",
+        ),
+    ),
+    HAMBURG(
+        "Hamburg",
+        mapOf(
+            ListingSource.KLEINANZEIGEN to "hamburg/c203l9409",
+            ListingSource.IMMOSCOUT to "Hamburg",
+            ListingSource.IMMONET to "hamburg",
+            ListingSource.IMMOWELT to "hamburg",
+            ListingSource.WOHNUNGSBOERSE to "hamburg",
+        ),
+    ),
+    MUNICH(
+        "München",
+        mapOf(
+            ListingSource.KLEINANZEIGEN to "muenchen/c203l6436",
+            ListingSource.IMMOSCOUT to "München",
+            ListingSource.IMMONET to "muenchen",
+            ListingSource.IMMOWELT to "muenchen",
+            ListingSource.WOHNUNGSBOERSE to "muenchen",
+        ),
+    ),
+    COLOGNE(
+        "Köln",
+        mapOf(
+            ListingSource.KLEINANZEIGEN to "koeln/c203l9480",
+            ListingSource.IMMOSCOUT to "Köln",
+            ListingSource.IMMONET to "koeln",
+            ListingSource.IMMOWELT to "koeln",
+            ListingSource.WOHNUNGSBOERSE to "koeln",
+        ),
+    ),
+    FRANKFURT(
+        "Frankfurt am Main",
+        mapOf(
+            ListingSource.KLEINANZEIGEN to "frankfurt-main/c203l1723",
+            ListingSource.IMMOSCOUT to "Frankfurt am Main",
+            ListingSource.IMMONET to "frankfurt-am-main",
+            ListingSource.IMMOWELT to "frankfurt-am-main",
+            ListingSource.WOHNUNGSBOERSE to "frankfurt-am-main",
+        ),
+    ),
+    STUTTGART(
+        "Stuttgart",
+        mapOf(
+            ListingSource.KLEINANZEIGEN to "stuttgart/c203l11538",
+            ListingSource.IMMOSCOUT to "Stuttgart",
+            ListingSource.IMMONET to "stuttgart",
+            ListingSource.IMMOWELT to "stuttgart",
+            ListingSource.WOHNUNGSBOERSE to "stuttgart",
+        ),
+    ),
+    DUSSELDORF(
+        "Düsseldorf",
+        mapOf(
+            ListingSource.KLEINANZEIGEN to "duesseldorf/c203l9435",
+            ListingSource.IMMOSCOUT to "Düsseldorf",
+            ListingSource.IMMONET to "duesseldorf",
+            ListingSource.IMMOWELT to "duesseldorf",
+            ListingSource.WOHNUNGSBOERSE to "duesseldorf",
+        ),
+    );
+
+    fun pathFor(source: ListingSource): String =
+        providerPaths[source] ?: displayName
 }
 
 /**

--- a/app/src/main/java/com/example/getfast/repository/ListingRepository.kt
+++ b/app/src/main/java/com/example/getfast/repository/ListingRepository.kt
@@ -55,7 +55,8 @@ class ListingRepository(
     }
 
     private suspend fun fetchKleinanzeigen(filter: SearchFilter): List<Listing> {
-        val url = "https://www.kleinanzeigen.de/s-wohnung-mieten/${filter.city.urlPath}"
+        val path = filter.city.pathFor(ListingSource.KLEINANZEIGEN)
+        val url = "https://www.kleinanzeigen.de/s-wohnung-mieten/$path"
         return try {
             val doc = fetcher.fetch(url)
             parser.parse(doc)
@@ -65,7 +66,8 @@ class ListingRepository(
     }
 
     private suspend fun fetchImmoscout(filter: SearchFilter): List<Listing> {
-        val url = "https://www.immobilienscout24.de/Suche/radius/wohnung-mieten?centerofsearchaddress=${filter.city.displayName}"
+        val city = filter.city.pathFor(ListingSource.IMMOSCOUT)
+        val url = "https://www.immobilienscout24.de/Suche/radius/wohnung-mieten?centerofsearchaddress=$city"
         return try {
             val doc = fetcher.fetch(url)
             parser.parseImmoscout(doc)
@@ -75,7 +77,8 @@ class ListingRepository(
     }
 
     private suspend fun fetchImmonet(filter: SearchFilter): List<Listing> {
-        val url = "https://www.immonet.de/${filter.city.displayName}"
+        val city = filter.city.pathFor(ListingSource.IMMONET)
+        val url = "https://www.immonet.de/$city"
         return try {
             val doc = fetcher.fetch(url)
             parser.parseImmonet(doc)
@@ -85,7 +88,8 @@ class ListingRepository(
     }
 
     private suspend fun fetchImmowelt(filter: SearchFilter): List<Listing> {
-        val url = "https://www.immowelt.de/${filter.city.displayName}"
+        val city = filter.city.pathFor(ListingSource.IMMOWELT)
+        val url = "https://www.immowelt.de/$city"
         return try {
             val doc = fetcher.fetch(url)
             parser.parseImmowelt(doc)
@@ -95,7 +99,8 @@ class ListingRepository(
     }
 
     private suspend fun fetchWohnungsboerse(filter: SearchFilter): List<Listing> {
-        val url = "https://www.wohnungsboerse.net/${filter.city.displayName}"
+        val city = filter.city.pathFor(ListingSource.WOHNUNGSBOERSE)
+        val url = "https://www.wohnungsboerse.net/$city"
         return try {
             val doc = fetcher.fetch(url)
             parser.parseWohnungsboerse(doc)


### PR DESCRIPTION
## Summary
- support provider-specific city paths/IDs in `SearchFilter` and `ListingRepository`
- add additional German cities including Cologne, Frankfurt, Stuttgart and Düsseldorf

## Testing
- `./gradlew test` *(fails: No such file or directory)*
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0a86b0bd08326b4377358a3aeffc8