### PR TITLE
Modularize listing providers and add ImmoScout support

### DIFF
--- a/app/src/main/java/com/example/getfast/repository/ImmonetProvider.kt
+++ b/app/src/main/java/com/example/getfast/repository/ImmonetProvider.kt
@@ -1,0 +1,26 @@
+package com.example.getfast.repository
+
+import com.example.getfast.model.Listing
+import com.example.getfast.model.ListingSource
+import com.example.getfast.model.SearchFilter
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
+
+/** Provider für Immonet. */
+class ImmonetProvider(
+    private val fetcher: HtmlFetcher = JsoupHtmlFetcher(),
+    private val parser: ListingParser = ListingParser(),
+) : ListingProvider {
+    override val source: ListingSource = ListingSource.IMMONET
+
+    override suspend fun fetchListings(filter: SearchFilter): List<Listing> {
+        val city = URLEncoder.encode(filter.city.displayName, StandardCharsets.UTF_8)
+        val price = filter.maxPrice?.let { "&toprice=$it" } ?: ""
+        val url = "https://www.immonet.de/wohnung-mieten.html?city=$city$price"
+        return runCatching {
+            val doc = fetcher.fetch(url)
+            parser.parseImmonet(doc)
+        }.getOrElse { emptyList() }
+    }
+}
+

--- a/app/src/main/java/com/example/getfast/repository/ImmoscoutProvider.kt
+++ b/app/src/main/java/com/example/getfast/repository/ImmoscoutProvider.kt
@@ -1,0 +1,26 @@
+package com.example.getfast.repository
+
+import com.example.getfast.model.Listing
+import com.example.getfast.model.ListingSource
+import com.example.getfast.model.SearchFilter
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
+
+/** Provider für ImmoScout24. */
+class ImmoscoutProvider(
+    private val fetcher: HtmlFetcher = JsoupHtmlFetcher(),
+    private val parser: ListingParser = ListingParser(),
+) : ListingProvider {
+    override val source: ListingSource = ListingSource.IMMOSCOUT
+
+    override suspend fun fetchListings(filter: SearchFilter): List<Listing> {
+        val city = URLEncoder.encode(filter.city.displayName, StandardCharsets.UTF_8)
+        val price = filter.maxPrice?.let { "&price=-$it" } ?: ""
+        val url = "https://www.immobilienscout24.de/Suche/radius/wohnung-mieten?centerofsearchaddress=$city$price"
+        return runCatching {
+            val doc = fetcher.fetch(url)
+            parser.parseImmoscout(doc)
+        }.getOrElse { emptyList() }
+    }
+}
+

--- a/app/src/main/java/com/example/getfast/repository/ImmoweltProvider.kt
+++ b/app/src/main/java/com/example/getfast/repository/ImmoweltProvider.kt
@@ -1,0 +1,26 @@
+package com.example.getfast.repository
+
+import com.example.getfast.model.Listing
+import com.example.getfast.model.ListingSource
+import com.example.getfast.model.SearchFilter
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
+
+/** Provider für Immowelt. */
+class ImmoweltProvider(
+    private val fetcher: HtmlFetcher = JsoupHtmlFetcher(),
+    private val parser: ListingParser = ListingParser(),
+) : ListingProvider {
+    override val source: ListingSource = ListingSource.IMMOWELT
+
+    override suspend fun fetchListings(filter: SearchFilter): List<Listing> {
+        val city = URLEncoder.encode(filter.city.displayName, StandardCharsets.UTF_8)
+        val price = filter.maxPrice?.let { "&maxprice=$it" } ?: ""
+        val url = "https://www.immowelt.de/suche/wohnung-mieten?city=$city$price"
+        return runCatching {
+            val doc = fetcher.fetch(url)
+            parser.parseImmowelt(doc)
+        }.getOrElse { emptyList() }
+    }
+}
+

--- a/app/src/main/java/com/example/getfast/repository/KleinanzeigenProvider.kt
+++ b/app/src/main/java/com/example/getfast/repository/KleinanzeigenProvider.kt
@@ -1,0 +1,25 @@
+package com.example.getfast.repository
+
+import com.example.getfast.model.Listing
+import com.example.getfast.model.ListingSource
+import com.example.getfast.model.SearchFilter
+
+/**
+ * Provider für Anzeigen von eBay Kleinanzeigen.
+ */
+class KleinanzeigenProvider(
+    private val fetcher: HtmlFetcher = JsoupHtmlFetcher(),
+    private val parser: ListingParser = ListingParser(),
+) : ListingProvider {
+    override val source: ListingSource = ListingSource.KLEINANZEIGEN
+
+    override suspend fun fetchListings(filter: SearchFilter): List<Listing> {
+        val path = filter.city.pathFor(source)
+        val url = "https://www.kleinanzeigen.de/s-wohnung-mieten/$path"
+        return runCatching {
+            val doc = fetcher.fetch(url)
+            parser.parse(doc)
+        }.getOrElse { emptyList() }
+    }
+}
+

--- a/app/src/main/java/com/example/getfast/repository/ListingProvider.kt
+++ b/app/src/main/java/com/example/getfast/repository/ListingProvider.kt
@@ -1,0 +1,20 @@
+package com.example.getfast.repository
+
+import com.example.getfast.model.Listing
+import com.example.getfast.model.SearchFilter
+import com.example.getfast.model.ListingSource
+
+/**
+ * Allgemeine Schnittstelle für einen Anbieter von Wohnungsanzeigen.
+ */
+interface ListingProvider {
+    /** Quelle, die dieser Provider bedient. */
+    val source: ListingSource
+
+    /**
+     * Lädt und parst Listings entsprechend des Filters.
+     * Fehler sollten zu einer leeren Liste führen.
+     */
+    suspend fun fetchListings(filter: SearchFilter): List<Listing>
+}
+

--- a/app/src/main/java/com/example/getfast/repository/ListingRepository.kt
+++ b/app/src/main/java/com/example/getfast/repository/ListingRepository.kt
@@ -1,44 +1,30 @@
 package com.example.getfast.repository
 
 import com.example.getfast.model.Listing
-import com.example.getfast.model.SearchFilter
 import com.example.getfast.model.ListingSource
+import com.example.getfast.model.SearchFilter
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import java.util.Locale
-import java.net.URLEncoder
-import java.nio.charset.StandardCharsets
 
 /**
  * Repository zum Abrufen und Filtern von Wohnungsanzeigen.
- * Die konkreten Schritte wie Netzwerkzugriff und Parsing
- * werden über eigene Klassen delegiert, damit die Klasse
- * klein und erweiterbar bleibt.
+ * Die konkreten Schritte zum Laden und Parsen der Anbieter
+ * werden an implementierungen von [ListingProvider] delegiert.
  */
 class ListingRepository(
-    private val fetcher: HtmlFetcher = JsoupHtmlFetcher(),
-    private val parser: ListingParser = ListingParser(),
+    private val providers: Map<ListingSource, ListingProvider> = defaultProviders(),
 ) {
     /**
      * Lädt aktuelle Listings entsprechend dem Filter.
-     * Fehler führen zu einer leeren Liste.
+     * Fehler einzelner Anbieter führen zu einer leeren Liste
+     * für diesen Anbieter.
      */
     suspend fun fetchLatestListings(filter: SearchFilter): List<Listing> {
         val results = mutableListOf<Listing>()
-        if (ListingSource.KLEINANZEIGEN in filter.sources) {
-            results += fetchKleinanzeigen(filter)
-        }
-        if (ListingSource.IMMOSCOUT in filter.sources) {
-            results += fetchImmoscout(filter)
-        }
-        if (ListingSource.IMMONET in filter.sources) {
-            results += fetchImmonet(filter)
-        }
-        if (ListingSource.IMMOWELT in filter.sources) {
-            results += fetchImmowelt(filter)
-        }
-        if (ListingSource.WOHNUNGSBOERSE in filter.sources) {
-            results += fetchWohnungsboerse(filter)
+        for (source in filter.sources) {
+            val provider = providers[source] ?: continue
+            results += provider.fetchListings(filter)
         }
         val maxPrice = filter.maxPrice
         val priceFiltered = if (maxPrice != null) {
@@ -53,71 +39,6 @@ class ListingRepository(
         val maxDays = filter.maxAgeDays.coerceAtMost(3)
         return priceFiltered.filter { listing ->
             isWithinDays(listing.date, maxDays)
-        }
-    }
-
-    private suspend fun fetchKleinanzeigen(filter: SearchFilter): List<Listing> {
-        val path = filter.city.pathFor(ListingSource.KLEINANZEIGEN)
-        val url = "https://www.kleinanzeigen.de/s-wohnung-mieten/$path"
-        return try {
-            val doc = fetcher.fetch(url)
-            parser.parse(doc)
-        } catch (e: Exception) {
-            emptyList()
-        }
-    }
-
-    private suspend fun fetchImmoscout(filter: SearchFilter): List<Listing> {
-        val city = URLEncoder.encode(filter.city.displayName, StandardCharsets.UTF_8)
-        val price = filter.maxPrice?.let { "&price=-$it" } ?: ""
-        val url = "https://www.immobilienscout24.de/Suche/radius/wohnung-mieten?centerofsearchaddress=$city$price"
-        return try {
-            val doc = fetcher.fetch(url)
-            parser.parseImmoscout(doc)
-        } catch (e: Exception) {
-            emptyList()
-        }
-    }
-
-    private suspend fun fetchImmonet(filter: SearchFilter): List<Listing> {
-        val city = URLEncoder.encode(filter.city.displayName, StandardCharsets.UTF_8)
-        val price = filter.maxPrice?.let { "&toprice=$it" } ?: ""
-        val url = "https://www.immonet.de/wohnung-mieten.html?city=$city$price"
-
-        return try {
-            val doc = fetcher.fetch(url)
-            parser.parseImmonet(doc)
-        } catch (e: Exception) {
-            emptyList()
-        }
-    }
-
-    private suspend fun fetchImmowelt(filter: SearchFilter): List<Listing> {
-
-        val city = URLEncoder.encode(filter.city.displayName, StandardCharsets.UTF_8)
-        val price = filter.maxPrice?.let { "&maxprice=$it" } ?: ""
-        val url = "https://www.immowelt.de/suche/wohnung-mieten?city=$city$price"
-        return try {
-            val doc = fetcher.fetch(url)
-            parser.parseImmowelt(doc)
-        } catch (e: Exception) {
-            emptyList()
-        }
-    }
-
-    private suspend fun fetchWohnungsboerse(filter: SearchFilter): List<Listing> {
-        val city = URLEncoder.encode(filter.city.displayName, StandardCharsets.UTF_8)
-        val price = filter.maxPrice?.let { "?maxMiete=$it" } ?: ""
-        val url = if (price.isEmpty()) {
-            "https://www.wohnungsboerse.net/$city/mietwohnungen"
-        } else {
-            "https://www.wohnungsboerse.net/$city/mietwohnungen$price"
-        }
-        return try {
-            val doc = fetcher.fetch(url)
-            parser.parseWohnungsboerse(doc)
-        } catch (e: Exception) {
-            emptyList()
         }
     }
 
@@ -140,4 +61,19 @@ class ListingRepository(
             }
         }
     }
+
+    companion object {
+        private fun defaultProviders(): Map<ListingSource, ListingProvider> {
+            val fetcher = JsoupHtmlFetcher()
+            val parser = ListingParser()
+            return mapOf(
+                ListingSource.KLEINANZEIGEN to KleinanzeigenProvider(fetcher, parser),
+                ListingSource.IMMOSCOUT to ImmoscoutProvider(fetcher, parser),
+                ListingSource.IMMONET to ImmonetProvider(fetcher, parser),
+                ListingSource.IMMOWELT to ImmoweltProvider(fetcher, parser),
+                ListingSource.WOHNUNGSBOERSE to WohnungsboerseProvider(fetcher, parser),
+            )
+        }
+    }
 }
+

--- a/app/src/main/java/com/example/getfast/repository/WohnungsboerseProvider.kt
+++ b/app/src/main/java/com/example/getfast/repository/WohnungsboerseProvider.kt
@@ -1,0 +1,30 @@
+package com.example.getfast.repository
+
+import com.example.getfast.model.Listing
+import com.example.getfast.model.ListingSource
+import com.example.getfast.model.SearchFilter
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
+
+/** Provider für Wohnungsboerse.net. */
+class WohnungsboerseProvider(
+    private val fetcher: HtmlFetcher = JsoupHtmlFetcher(),
+    private val parser: ListingParser = ListingParser(),
+) : ListingProvider {
+    override val source: ListingSource = ListingSource.WOHNUNGSBOERSE
+
+    override suspend fun fetchListings(filter: SearchFilter): List<Listing> {
+        val city = URLEncoder.encode(filter.city.displayName, StandardCharsets.UTF_8)
+        val price = filter.maxPrice?.let { "?maxMiete=$it" } ?: ""
+        val url = if (price.isEmpty()) {
+            "https://www.wohnungsboerse.net/$city/mietwohnungen"
+        } else {
+            "https://www.wohnungsboerse.net/$city/mietwohnungen$price"
+        }
+        return runCatching {
+            val doc = fetcher.fetch(url)
+            parser.parseWohnungsboerse(doc)
+        }.getOrElse { emptyList() }
+    }
+}
+

--- a/app/src/test/java/com/example/getfast/ListingRepositoryTest.kt
+++ b/app/src/test/java/com/example/getfast/ListingRepositoryTest.kt
@@ -2,8 +2,14 @@ package com.example.getfast
 
 import com.example.getfast.model.SearchFilter
 import com.example.getfast.model.ListingSource
-import com.example.getfast.repository.ListingRepository
 import com.example.getfast.repository.HtmlFetcher
+import com.example.getfast.repository.ImmoscoutProvider
+import com.example.getfast.repository.ImmonetProvider
+import com.example.getfast.repository.ImmoweltProvider
+import com.example.getfast.repository.KleinanzeigenProvider
+import com.example.getfast.repository.ListingParser
+import com.example.getfast.repository.ListingRepository
+import com.example.getfast.repository.WohnungsboerseProvider
 import kotlinx.coroutines.runBlocking
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
@@ -20,7 +26,8 @@ class ListingRepositoryTest {
 
     @Test
     fun fetchLatestListings_filtersByMaxPrice() = runBlocking {
-        val repo = ListingRepository(fetcher = FakeFetcher(loadHtml("kleinanzeigen.html")))
+        val provider = KleinanzeigenProvider(fetcher = FakeFetcher(loadHtml("kleinanzeigen.html")), parser = ListingParser())
+        val repo = ListingRepository(providers = mapOf(ListingSource.KLEINANZEIGEN to provider))
         val listings = repo.fetchLatestListings(SearchFilter(maxPrice = 60))
         assertEquals(1, listings.size)
         assertEquals("2", listings[0].id)
@@ -28,7 +35,8 @@ class ListingRepositoryTest {
 
     @Test
     fun fetchLatestListings_returnsImmoscoutListings() = runBlocking {
-        val repo = ListingRepository(fetcher = FakeFetcher(loadHtml("immoscout.html")))
+        val provider = ImmoscoutProvider(fetcher = FakeFetcher(loadHtml("immoscout.html")), parser = ListingParser())
+        val repo = ListingRepository(providers = mapOf(ListingSource.IMMOSCOUT to provider))
         val filter = SearchFilter(sources = setOf(ListingSource.IMMOSCOUT))
         val listings = repo.fetchLatestListings(filter)
         assertEquals(1, listings.size)
@@ -39,7 +47,8 @@ class ListingRepositoryTest {
 
     @Test
     fun fetchLatestListings_returnsImmonetListings() = runBlocking {
-        val repo = ListingRepository(fetcher = FakeFetcher(loadHtml("immonet.html")))
+        val provider = ImmonetProvider(fetcher = FakeFetcher(loadHtml("immonet.html")), parser = ListingParser())
+        val repo = ListingRepository(providers = mapOf(ListingSource.IMMONET to provider))
         val filter = SearchFilter(sources = setOf(ListingSource.IMMONET))
         val listings = repo.fetchLatestListings(filter)
         assertEquals(1, listings.size)
@@ -50,7 +59,8 @@ class ListingRepositoryTest {
 
     @Test
     fun fetchLatestListings_returnsImmoweltListings() = runBlocking {
-        val repo = ListingRepository(fetcher = FakeFetcher(loadHtml("immowelt.html")))
+        val provider = ImmoweltProvider(fetcher = FakeFetcher(loadHtml("immowelt.html")), parser = ListingParser())
+        val repo = ListingRepository(providers = mapOf(ListingSource.IMMOWELT to provider))
         val filter = SearchFilter(sources = setOf(ListingSource.IMMOWELT))
         val listings = repo.fetchLatestListings(filter)
         assertEquals(1, listings.size)
@@ -61,7 +71,8 @@ class ListingRepositoryTest {
 
     @Test
     fun fetchLatestListings_returnsWohnungsboerseListings() = runBlocking {
-        val repo = ListingRepository(fetcher = FakeFetcher(loadHtml("wohnungsboerse.html")))
+        val provider = WohnungsboerseProvider(fetcher = FakeFetcher(loadHtml("wohnungsboerse.html")), parser = ListingParser())
+        val repo = ListingRepository(providers = mapOf(ListingSource.WOHNUNGSBOERSE to provider))
         val filter = SearchFilter(sources = setOf(ListingSource.WOHNUNGSBOERSE))
         val listings = repo.fetchLatestListings(filter)
         assertEquals(1, listings.size)
@@ -72,7 +83,8 @@ class ListingRepositoryTest {
 
     @Test
     fun fetchLatestListings_filtersByMaxAge() = runBlocking {
-        val repo = ListingRepository(fetcher = FakeFetcher(loadHtml("kleinanzeigen_old.html")))
+        val provider = KleinanzeigenProvider(fetcher = FakeFetcher(loadHtml("kleinanzeigen_old.html")), parser = ListingParser())
+        val repo = ListingRepository(providers = mapOf(ListingSource.KLEINANZEIGEN to provider))
         val filter = SearchFilter(maxAgeDays = 3)
         val listings = repo.fetchLatestListings(filter)
         assertEquals(1, listings.size)


### PR DESCRIPTION
## Summary
- Delegate fetching logic to new `ListingProvider` implementations for Kleinanzeigen, ImmoScout, Immonet, Immowelt and Wohnungsbörse
- Refactor `ListingRepository` to use pluggable providers for extensibility
- Update tests to exercise new provider-based architecture

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0ac237ce8832680427d3ad6ba74ad