### PR TITLE
Fix URLEncoder usage for Android API compatibility

### DIFF
--- a/app/src/main/java/com/example/getfast/repository/ImmonetProvider.kt
+++ b/app/src/main/java/com/example/getfast/repository/ImmonetProvider.kt
@@ -14,7 +14,7 @@ class ImmonetProvider(
     override val source: ListingSource = ListingSource.IMMONET
 
     override suspend fun fetchListings(filter: SearchFilter): List<Listing> {
-        val city = URLEncoder.encode(filter.city.displayName, StandardCharsets.UTF_8)
+        val city = URLEncoder.encode(filter.city.displayName, StandardCharsets.UTF_8.toString())
         val price = filter.maxPrice?.let { "&toprice=$it" } ?: ""
         val url = "https://www.immonet.de/wohnung-mieten.html?city=$city$price"
         return runCatching {

--- a/app/src/main/java/com/example/getfast/repository/ImmoscoutProvider.kt
+++ b/app/src/main/java/com/example/getfast/repository/ImmoscoutProvider.kt
@@ -14,7 +14,7 @@ class ImmoscoutProvider(
     override val source: ListingSource = ListingSource.IMMOSCOUT
 
     override suspend fun fetchListings(filter: SearchFilter): List<Listing> {
-        val city = URLEncoder.encode(filter.city.displayName, StandardCharsets.UTF_8)
+        val city = URLEncoder.encode(filter.city.displayName, StandardCharsets.UTF_8.toString())
         val price = filter.maxPrice?.let { "&price=-$it" } ?: ""
         val url = "https://www.immobilienscout24.de/Suche/radius/wohnung-mieten?centerofsearchaddress=$city$price"
         return runCatching {

--- a/app/src/main/java/com/example/getfast/repository/ImmoweltProvider.kt
+++ b/app/src/main/java/com/example/getfast/repository/ImmoweltProvider.kt
@@ -14,7 +14,7 @@ class ImmoweltProvider(
     override val source: ListingSource = ListingSource.IMMOWELT
 
     override suspend fun fetchListings(filter: SearchFilter): List<Listing> {
-        val city = URLEncoder.encode(filter.city.displayName, StandardCharsets.UTF_8)
+        val city = URLEncoder.encode(filter.city.displayName, StandardCharsets.UTF_8.toString())
         val price = filter.maxPrice?.let { "&maxprice=$it" } ?: ""
         val url = "https://www.immowelt.de/suche/wohnung-mieten?city=$city$price"
         return runCatching {

--- a/app/src/main/java/com/example/getfast/repository/WohnungsboerseProvider.kt
+++ b/app/src/main/java/com/example/getfast/repository/WohnungsboerseProvider.kt
@@ -14,7 +14,7 @@ class WohnungsboerseProvider(
     override val source: ListingSource = ListingSource.WOHNUNGSBOERSE
 
     override suspend fun fetchListings(filter: SearchFilter): List<Listing> {
-        val city = URLEncoder.encode(filter.city.displayName, StandardCharsets.UTF_8)
+        val city = URLEncoder.encode(filter.city.displayName, StandardCharsets.UTF_8.toString())
         val price = filter.maxPrice?.let { "?maxMiete=$it" } ?: ""
         val url = if (price.isEmpty()) {
             "https://www.wohnungsboerse.net/$city/mietwohnungen"


### PR DESCRIPTION
## Summary
- Avoid API 33 URLEncoder#encode(Charset) by using string-based encoding
- Apply fix across Immoscout, Immonet, Immowelt and Wohnungsboerse providers

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0c7f482b483269e1453777b370a31