### PR TITLE
feat: separate provider activities and show empty state

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,5 +16,10 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <activity android:name=".ui.ImmoscoutActivity" />
+        <activity android:name=".ui.KleinanzeigenActivity" />
+        <activity android:name=".ui.ImmonetActivity" />
+        <activity android:name=".ui.ImmoweltActivity" />
+        <activity android:name=".ui.WohnungsboerseActivity" />
     </application>
 </manifest>

--- a/app/src/main/java/com/example/getfast/ui/ProviderActivity.kt
+++ b/app/src/main/java/com/example/getfast/ui/ProviderActivity.kt
@@ -1,0 +1,109 @@
+package com.example.getfast.ui
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.activity.viewModels
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.example.getfast.R
+import com.example.getfast.model.ListingSource
+import com.example.getfast.ui.components.ListingList
+import com.example.getfast.ui.theme.GetFastTheme
+import com.example.getfast.viewmodel.ProviderViewModel
+
+/**
+ * Basisklasse für Aktivitäten, die Listings eines einzelnen Anbieters anzeigen.
+ */
+abstract class ProviderActivity : ComponentActivity() {
+
+    /** Der Anbieter, für den diese Activity zuständig ist. */
+    protected abstract val source: ListingSource
+
+    private val viewModel: ProviderViewModel by viewModels {
+        ProviderViewModel.factory(application, source)
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            GetFastTheme {
+                val listings by viewModel.listings.collectAsState()
+                val lastFetch by viewModel.lastFetchTime.collectAsState()
+                val isRefreshing by viewModel.isRefreshing.collectAsState()
+                Column(modifier = Modifier.fillMaxSize()) {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(8.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Text(
+                            text = stringResource(
+                                id = R.string.last_fetch,
+                                lastFetch ?: "--",
+                            ),
+                            style = MaterialTheme.typography.bodySmall,
+                        )
+                        Spacer(modifier = Modifier.weight(1f))
+                        TextButton(onClick = { viewModel.refreshListings() }) {
+                            Text(text = stringResource(id = R.string.refresh))
+                        }
+                    }
+                    ListingList(
+                        listings = listings,
+                        favorites = emptySet(),
+                        favoritesOnly = false,
+                        onToggleFavorite = {},
+                        highlightedIds = emptySet(),
+                        blinkingIds = emptySet(),
+                        isRefreshing = isRefreshing,
+                        onRefresh = { viewModel.refreshListings() },
+                        onArchive = {},
+                        modifier = Modifier.weight(1f),
+                    )
+                }
+            }
+        }
+        viewModel.refreshListings()
+    }
+}
+
+/** Aktivität für ImmoScout24. */
+class ImmoscoutActivity : ProviderActivity() {
+    override val source: ListingSource = ListingSource.IMMOSCOUT
+}
+
+/** Aktivität für Kleinanzeigen. */
+class KleinanzeigenActivity : ProviderActivity() {
+    override val source: ListingSource = ListingSource.KLEINANZEIGEN
+}
+
+/** Aktivität für Immonet. */
+class ImmonetActivity : ProviderActivity() {
+    override val source: ListingSource = ListingSource.IMMONET
+}
+
+/** Aktivität für Immowelt. */
+class ImmoweltActivity : ProviderActivity() {
+    override val source: ListingSource = ListingSource.IMMOWELT
+}
+
+/** Aktivität für Wohnungsboerse. */
+class WohnungsboerseActivity : ProviderActivity() {
+    override val source: ListingSource = ListingSource.WOHNUNGSBOERSE
+}
+

--- a/app/src/main/java/com/example/getfast/ui/components/ListingComponents.kt
+++ b/app/src/main/java/com/example/getfast/ui/components/ListingComponents.kt
@@ -112,44 +112,51 @@ fun ListingList(
                 ),
             )
     ) {
-        LazyColumn(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(16.dp),
-        ) {
-            items(items = shownListings, key = { it.id }) { listing ->
-                val dismissState = rememberDismissState(
-                    confirmStateChange = { value ->
-                        if (value == DismissValue.DismissedToEnd) {
-                            onArchive(listing)
-                            true
-                        } else {
-                            false
+        if (shownListings.isEmpty() && !isRefreshing) {
+            Text(
+                text = stringResource(id = R.string.no_listings_found),
+                modifier = Modifier.align(Alignment.Center)
+            )
+        } else {
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(16.dp),
+            ) {
+                items(items = shownListings, key = { it.id }) { listing ->
+                    val dismissState = rememberDismissState(
+                        confirmStateChange = { value ->
+                            if (value == DismissValue.DismissedToEnd) {
+                                onArchive(listing)
+                                true
+                            } else {
+                                false
+                            }
                         }
-                    }
-                )
-                SwipeToDismiss(
-                    state = dismissState,
-                    background = {},
-                    dismissContent = {
-                        val isKlein = remember(listing.url) { listing.url.contains("kleinanzeigen", ignoreCase = true) }
-                        val cardColor = if (isKlein) {
-                            Color(0xFFE8F5E9)
-                        } else {
-                            Color(0xFFE3F2FD)
-                        }
-                        ListingCard(
-                            listing = listing,
-                            isFavorite = favorites.contains(listing.id),
-                            onToggleFavorite = onToggleFavorite,
-                            highlighted = highlightedIds.contains(listing.id),
-                            blink = blinkingIds.contains(listing.id),
-                            onClick = { selectedListing = listing },
-                            cardColor = cardColor,
-                        )
-                    },
-                    directions = setOf(DismissDirection.StartToEnd),
-                )
+                    )
+                    SwipeToDismiss(
+                        state = dismissState,
+                        background = {},
+                        dismissContent = {
+                            val isKlein = remember(listing.url) { listing.url.contains("kleinanzeigen", ignoreCase = true) }
+                            val cardColor = if (isKlein) {
+                                Color(0xFFE8F5E9)
+                            } else {
+                                Color(0xFFE3F2FD)
+                            }
+                            ListingCard(
+                                listing = listing,
+                                isFavorite = favorites.contains(listing.id),
+                                onToggleFavorite = onToggleFavorite,
+                                highlighted = highlightedIds.contains(listing.id),
+                                blink = blinkingIds.contains(listing.id),
+                                onClick = { selectedListing = listing },
+                                cardColor = cardColor,
+                            )
+                        },
+                        directions = setOf(DismissDirection.StartToEnd),
+                    )
+                }
             }
         }
 

--- a/app/src/main/java/com/example/getfast/viewmodel/ProviderViewModel.kt
+++ b/app/src/main/java/com/example/getfast/viewmodel/ProviderViewModel.kt
@@ -1,0 +1,66 @@
+package com.example.getfast.viewmodel
+
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import com.example.getfast.model.Listing
+import com.example.getfast.model.ListingSource
+import com.example.getfast.model.SearchFilter
+import com.example.getfast.repository.ListingRepository
+import java.text.DateFormat
+import java.util.Date
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+
+/**
+ * ViewModel zum Laden von Listings für einen einzelnen Anbieter.
+ * Jeder Provider erhält eine eigene Instanz dieser ViewModels.
+ */
+class ProviderViewModel(
+    application: Application,
+    private val source: ListingSource,
+) : AndroidViewModel(application) {
+
+    private val repository = ListingRepository()
+
+    private val _listings = MutableStateFlow<List<Listing>>(emptyList())
+    val listings: StateFlow<List<Listing>> = _listings
+
+    private val formatter = DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.SHORT)
+    private val _lastFetchTime = MutableStateFlow<String?>(null)
+    val lastFetchTime: StateFlow<String?> = _lastFetchTime
+
+    private val _isRefreshing = MutableStateFlow(false)
+    val isRefreshing: StateFlow<Boolean> = _isRefreshing
+
+    /**
+     * Lädt die neuesten Listings für den konfigurierten Anbieter.
+     */
+    fun refreshListings() {
+        viewModelScope.launch {
+            _isRefreshing.value = true
+            val filter = SearchFilter(sources = setOf(source))
+            _listings.value = repository.fetchLatestListings(filter)
+            _lastFetchTime.value = formatter.format(Date())
+            _isRefreshing.value = false
+        }
+    }
+
+    companion object {
+        /** Factory zum Erzeugen eines ProviderViewModel mit Source Parameter. */
+        fun factory(application: Application, source: ListingSource): ViewModelProvider.Factory =
+            object : ViewModelProvider.AndroidViewModelFactory(application) {
+                override fun <T : ViewModel> create(modelClass: Class<T>): T {
+                    if (modelClass.isAssignableFrom(ProviderViewModel::class.java)) {
+                        @Suppress("UNCHECKED_CAST")
+                        return ProviderViewModel(application, source) as T
+                    }
+                    throw IllegalArgumentException("Unknown ViewModel class")
+                }
+            }
+    }
+}
+

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -33,4 +33,5 @@
     <string name="open_archive">Archiv anzeigen</string>
     <string name="reset_app">App zurücksetzen</string>
     <string name="archive_title">Archiv</string>
+    <string name="no_listings_found">Keine Anzeige gefunden</string>
 </resources>


### PR DESCRIPTION
## Summary
- introduce generic ProviderViewModel and ProviderActivity
- add dedicated activities for Immoscout, Kleinanzeigen, Immonet, Immowelt and Wohnungsboerse
- display a message when no listings are found

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0cb98a8f8832690d86737db6546dd