### PR TITLE
Pass system dark theme to GetFastTheme

### DIFF
--- a/app/src/main/java/com/example/getfast/ui/ProviderActivity.kt
+++ b/app/src/main/java/com/example/getfast/ui/ProviderActivity.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -40,7 +41,8 @@ abstract class ProviderActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
-            GetFastTheme {
+            val systemDark = isSystemInDarkTheme()
+            GetFastTheme(darkTheme = systemDark) {
                 val listings by viewModel.listings.collectAsState()
                 val lastFetch by viewModel.lastFetchTime.collectAsState()
                 val isRefreshing by viewModel.isRefreshing.collectAsState()


### PR DESCRIPTION
## Summary
- fix ProviderActivity to supply required `darkTheme` parameter by reading system theme

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0cfab6d8c8326a8547795238a9046