### PR TITLE
Use proxy fallback when fetching provider pages

### DIFF
--- a/app/src/main/java/com/example/getfast/repository/HtmlFetcher.kt
+++ b/app/src/main/java/com/example/getfast/repository/HtmlFetcher.kt
@@ -17,14 +17,34 @@ interface HtmlFetcher {
 
 /**
  * Standardimplementierung, die Jsoup zum Abrufen des HTML verwendet.
+ *
+ * Viele Immobilienportale blockieren direkte Zugriffe von Skripten und
+ * liefern HTTP-Fehler oder eine leere Antwort zurück. Um dennoch Inhalte
+ * laden zu können wird beim Auftreten eines Fehlers ein zweiter Versuch
+ * über den von "r.jina.ai" bereitgestellten Proxy unternommen. Dieser Proxy
+ * spiegelt öffentlich zugängliche Seiten und stellt eine einfache Möglichkeit
+ * dar, an das HTML zu gelangen ohne die ursprüngliche Domain direkt
+ * ansprechen zu müssen.
  */
 class JsoupHtmlFetcher : HtmlFetcher {
     override suspend fun fetch(url: String): Document = withContext(Dispatchers.IO) {
+        runCatching { connect(url).get() }
+            .recoverCatching {
+                val proxied = "https://r.jina.ai/$url"
+                connect(proxied).get()
+            }
+            .getOrThrow()
+    }
+
+    private fun connect(url: String) =
         Jsoup.connect(url)
-            .userAgent("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36")
+            .userAgent(
+                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) " +
+                    "AppleWebKit/537.36 (KHTML, wie Gecko) " +
+                    "Chrome/120.0.0.0 Safari/537.36"
+            )
             .referrer("https://www.google.com")
             .header("Accept-Language", "de-DE,de;q=0.9,en-US;q=0.8,en;q=0.7")
             .timeout(10000)
-            .get()
-    }
 }
+


### PR DESCRIPTION
## Summary
- add `r.jina.ai` proxy fallback to the HTML fetcher so providers other than eBay Kleinanzeigen can load data even when direct requests fail

## Testing
- `gradle test --quiet` *(fails: Plugin [id: 'com.android.application', version: '8.4.0', apply: false] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc54a96cac8326a96dc7fb66695034