### PR TITLE
feat: separate provider settings

### DIFF
--- a/app/src/main/java/com/example/getfast/ui/ProviderActivity.kt
+++ b/app/src/main/java/com/example/getfast/ui/ProviderActivity.kt
@@ -11,11 +11,17 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Menu
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -46,37 +52,53 @@ abstract class ProviderActivity : ComponentActivity() {
                 val listings by viewModel.listings.collectAsState()
                 val lastFetch by viewModel.lastFetchTime.collectAsState()
                 val isRefreshing by viewModel.isRefreshing.collectAsState()
-                Column(modifier = Modifier.fillMaxSize()) {
-                    Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(8.dp),
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        Text(
-                            text = stringResource(
-                                id = R.string.last_fetch,
-                                lastFetch ?: "--",
-                            ),
-                            style = MaterialTheme.typography.bodySmall,
-                        )
-                        Spacer(modifier = Modifier.weight(1f))
-                        TextButton(onClick = { viewModel.refreshListings() }) {
-                            Text(text = stringResource(id = R.string.refresh))
-                        }
-                    }
-                    ListingList(
-                        listings = listings,
-                        favorites = emptySet(),
-                        favoritesOnly = false,
-                        onToggleFavorite = {},
-                        highlightedIds = emptySet(),
-                        blinkingIds = emptySet(),
-                        isRefreshing = isRefreshing,
-                        onRefresh = { viewModel.refreshListings() },
-                        onArchive = {},
-                        modifier = Modifier.weight(1f),
+                val filter by viewModel.filter.collectAsState()
+                var showSettings by remember { mutableStateOf(false) }
+                if (showSettings) {
+                    ProviderSettingsScreen(
+                        filter = filter,
+                        onApply = {
+                            viewModel.updateFilter(it)
+                            showSettings = false
+                        },
+                        onBack = { showSettings = false },
                     )
+                } else {
+                    Column(modifier = Modifier.fillMaxSize()) {
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(8.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            IconButton(onClick = { showSettings = true }) {
+                                Icon(Icons.Default.Menu, contentDescription = stringResource(id = R.string.open_settings))
+                            }
+                            Text(
+                                text = stringResource(
+                                    id = R.string.last_fetch,
+                                    lastFetch ?: "--",
+                                ),
+                                style = MaterialTheme.typography.bodySmall,
+                            )
+                            Spacer(modifier = Modifier.weight(1f))
+                            TextButton(onClick = { viewModel.refreshListings() }) {
+                                Text(text = stringResource(id = R.string.refresh))
+                            }
+                        }
+                        ListingList(
+                            listings = listings,
+                            favorites = emptySet(),
+                            favoritesOnly = false,
+                            onToggleFavorite = {},
+                            highlightedIds = emptySet(),
+                            blinkingIds = emptySet(),
+                            isRefreshing = isRefreshing,
+                            onRefresh = { viewModel.refreshListings() },
+                            onArchive = {},
+                            modifier = Modifier.weight(1f),
+                        )
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/example/getfast/ui/ProviderSettingsScreen.kt
+++ b/app/src/main/java/com/example/getfast/ui/ProviderSettingsScreen.kt
@@ -1,0 +1,124 @@
+package com.example.getfast.ui
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material3.Button
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.example.getfast.R
+import com.example.getfast.model.City
+import com.example.getfast.model.SearchFilter
+
+/**
+ * Einstellungen für einen einzelnen Anbieter.
+ * Vorerst identisch für alle Provider, kann jedoch später
+ * individuell erweitert werden.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ProviderSettingsScreen(
+    filter: SearchFilter,
+    onApply: (SearchFilter) -> Unit,
+    onBack: () -> Unit,
+) {
+    var selectedCity by remember { mutableStateOf(filter.city) }
+    var priceText by remember { mutableStateOf(filter.maxPrice?.toString() ?: "") }
+    var daysText by remember { mutableStateOf(filter.maxAgeDays.toString()) }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp)
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            IconButton(onClick = onBack) {
+                Icon(Icons.Default.ArrowBack, contentDescription = stringResource(id = R.string.back))
+            }
+            Text(
+                text = stringResource(id = R.string.settings_title),
+                style = MaterialTheme.typography.titleLarge
+            )
+        }
+        Spacer(modifier = Modifier.height(16.dp))
+        var expanded by remember { mutableStateOf(false) }
+        ExposedDropdownMenuBox(
+            expanded = expanded,
+            onExpandedChange = { expanded = !expanded },
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            OutlinedTextField(
+                value = selectedCity.displayName,
+                onValueChange = {},
+                label = { Text(text = stringResource(id = R.string.city_label)) },
+                readOnly = true,
+                trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
+                modifier = Modifier.menuAnchor().fillMaxWidth()
+            )
+            DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+                City.values().forEach { city ->
+                    DropdownMenuItem(
+                        text = { Text(city.displayName) },
+                        onClick = {
+                            selectedCity = city
+                            expanded = false
+                        }
+                    )
+                }
+            }
+        }
+        Spacer(modifier = Modifier.height(16.dp))
+        OutlinedTextField(
+            value = priceText,
+            onValueChange = { priceText = it.filter { ch -> ch.isDigit() } },
+            label = { Text(text = stringResource(id = R.string.max_price_label)) },
+            modifier = Modifier.fillMaxWidth()
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        OutlinedTextField(
+            value = daysText,
+            onValueChange = { daysText = it.filter { ch -> ch.isDigit() }.take(1) },
+            label = { Text(text = stringResource(id = R.string.max_days_label)) },
+            modifier = Modifier.fillMaxWidth()
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        Button(
+            onClick = {
+                onApply(
+                    SearchFilter(
+                        city = selectedCity,
+                        maxPrice = priceText.toIntOrNull(),
+                        maxAgeDays = daysText.toIntOrNull()?.coerceIn(0, 3) ?: 3,
+                        sources = filter.sources
+                    )
+                )
+            },
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text(text = stringResource(id = R.string.apply_filters))
+        }
+    }
+}

--- a/app/src/main/java/com/example/getfast/viewmodel/ProviderViewModel.kt
+++ b/app/src/main/java/com/example/getfast/viewmodel/ProviderViewModel.kt
@@ -29,6 +29,9 @@ class ProviderViewModel(
     private val _listings = MutableStateFlow<List<Listing>>(emptyList())
     val listings: StateFlow<List<Listing>> = _listings
 
+    private val _filter = MutableStateFlow(SearchFilter(sources = setOf(source)))
+    val filter: StateFlow<SearchFilter> = _filter
+
     private val formatter = DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.SHORT)
     private val _lastFetchTime = MutableStateFlow<String?>(null)
     val lastFetchTime: StateFlow<String?> = _lastFetchTime
@@ -42,11 +45,18 @@ class ProviderViewModel(
     fun refreshListings() {
         viewModelScope.launch {
             _isRefreshing.value = true
-            val filter = SearchFilter(sources = setOf(source))
-            _listings.value = repository.fetchLatestListings(filter)
+            _listings.value = repository.fetchLatestListings(_filter.value)
             _lastFetchTime.value = formatter.format(Date())
             _isRefreshing.value = false
         }
+    }
+
+    /**
+     * Aktualisiert den Filter und lädt sofort neue Daten.
+     */
+    fun updateFilter(newFilter: SearchFilter) {
+        _filter.value = newFilter
+        refreshListings()
     }
 
     companion object {

--- a/app/src/test/java/com/example/getfast/repository/ListingRepositoryTest.kt
+++ b/app/src/test/java/com/example/getfast/repository/ListingRepositoryTest.kt
@@ -1,0 +1,44 @@
+package com.example.getfast.repository
+
+import com.example.getfast.model.ListingSource
+import com.example.getfast.model.SearchFilter
+import kotlinx.coroutines.runBlocking
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * Verifies that listings are returned even when Kleinanzeigen is excluded.
+ */
+class ListingRepositoryTest {
+
+    private fun providerFor(source: ListingSource, file: String): ListingProvider {
+        val fetcher = object : HtmlFetcher {
+            override suspend fun fetch(url: String): Document {
+                val html = this::class.java.getResource("/html/$file")!!.readText()
+                return Jsoup.parse(html)
+            }
+        }
+        val parser = ListingParser()
+        return when (source) {
+            ListingSource.IMMOSCOUT -> ImmoscoutProvider(fetcher, parser)
+            ListingSource.IMMONET -> ImmonetProvider(fetcher, parser)
+            ListingSource.IMMOWELT -> ImmoweltProvider(fetcher, parser)
+            ListingSource.WOHNUNGSBOERSE -> WohnungsboerseProvider(fetcher, parser)
+            ListingSource.KLEINANZEIGEN -> KleinanzeigenProvider(fetcher, parser)
+        }
+    }
+
+    @Test
+    fun `fetches listings without kleinanzeigen`() = runBlocking {
+        val repo = ListingRepository(
+            providers = mapOf(
+                ListingSource.IMMOSCOUT to providerFor(ListingSource.IMMOSCOUT, "immoscout.html"),
+            )
+        )
+        val filter = SearchFilter(sources = setOf(ListingSource.IMMOSCOUT))
+        val listings = repo.fetchLatestListings(filter)
+        assertTrue(listings.isNotEmpty(), "Expected listings from ImmoScout without Kleinanzeigen")
+    }
+}


### PR DESCRIPTION
## Summary
- introduce ProviderSettingsScreen composable for per-provider configuration
- add filter state to ProviderViewModel and expose provider-specific settings via burger menu
- add unit test ensuring listings can be fetched without Kleinanzeigen

## Testing
- `gradle test` *(fails: Plugin [id: 'org.jetbrains.kotlin.android', version: '1.9.23', apply: false] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc57cd7e3883268c6a8f8a325bb6c6