### PR TITLE
Ensure CI publishes debug APK artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,3 +40,12 @@ jobs:
 
       - name: Build
         run: gradle build --parallel
+
+      - name: Assemble debug APK
+        run: gradle :app:assembleDebug
+
+      - name: Upload debug APK artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-debug-apk
+          path: app/build/outputs/apk/debug/app-debug.apk


### PR DESCRIPTION
## Summary
- keep the existing CI build in place and add a dedicated assembleDebug step
- upload the generated debug APK as a workflow artifact so each CI run produces a downloadable binary

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d7c63e4f1c8326a9400e47455a88a2