### PR TITLE
Update CI to Gradle 8.14.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v3
         with:
-          gradle-version: 8.4
+          gradle-version: 8.14.3
       - name: Cache Gradle files
         uses: actions/cache@v3
         with:


### PR DESCRIPTION
## Summary
- update the GitHub Actions workflow to install Gradle 8.14.3 instead of the older 8.4 release so that the build uses a compatible version

## Testing
- not run (CI change only)


------
https://chatgpt.com/codex/tasks/task_e_68d7ccb445d083269f13ecb3cb6d7063