### PR TITLE
Improve city selection UX and handle back gestures

### DIFF
--- a/app/src/main/java/com/example/getfast/ui/ArchiveScreen.kt
+++ b/app/src/main/java/com/example/getfast/ui/ArchiveScreen.kt
@@ -1,5 +1,6 @@
 package com.example.getfast.ui
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -28,6 +29,7 @@ fun ArchiveScreen(
     onToggleFavorite: (Listing) -> Unit,
     onBack: () -> Unit,
 ) {
+    BackHandler(onBack = onBack)
     Column(modifier = Modifier.fillMaxSize()) {
         Row(
             verticalAlignment = Alignment.CenterVertically,

--- a/app/src/main/java/com/example/getfast/ui/ProviderSettingsScreen.kt
+++ b/app/src/main/java/com/example/getfast/ui/ProviderSettingsScreen.kt
@@ -1,5 +1,6 @@
 package com.example.getfast.ui
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -45,9 +46,12 @@ fun ProviderSettingsScreen(
     onApply: (SearchFilter) -> Unit,
     onBack: () -> Unit,
 ) {
+    BackHandler(onBack = onBack)
     var selectedCity by remember { mutableStateOf(filter.city) }
+    var cityQuery by remember { mutableStateOf(filter.city.displayName) }
     var priceText by remember { mutableStateOf(filter.maxPrice?.toString() ?: "") }
     var daysText by remember { mutableStateOf(filter.maxAgeDays.toString()) }
+    val allCities = remember { City.values().toList() }
 
     Column(
         modifier = Modifier
@@ -65,28 +69,60 @@ fun ProviderSettingsScreen(
         }
         Spacer(modifier = Modifier.height(16.dp))
         var expanded by remember { mutableStateOf(false) }
+        val filteredCities = remember(cityQuery) {
+            val query = cityQuery.trim()
+            if (query.isEmpty()) {
+                allCities
+            } else {
+                allCities.filter { it.displayName.contains(query, ignoreCase = true) }
+            }
+        }
         ExposedDropdownMenuBox(
             expanded = expanded,
             onExpandedChange = { expanded = !expanded },
             modifier = Modifier.fillMaxWidth()
         ) {
             OutlinedTextField(
-                value = selectedCity.displayName,
-                onValueChange = {},
+                value = cityQuery,
+                onValueChange = { input ->
+                    cityQuery = input
+                    expanded = true
+                    val normalized = input.trim()
+                    val exactMatch = allCities.firstOrNull { city ->
+                        city.displayName.equals(normalized, ignoreCase = true)
+                    }
+                    val suggestions = if (normalized.isEmpty()) allCities else allCities.filter {
+                        it.displayName.contains(normalized, ignoreCase = true)
+                    }
+                    if (exactMatch != null) {
+                        selectedCity = exactMatch
+                    } else if (suggestions.isNotEmpty() && selectedCity !in suggestions) {
+                        selectedCity = suggestions.first()
+                    }
+                },
                 label = { Text(text = stringResource(id = R.string.city_label)) },
-                readOnly = true,
+                singleLine = true,
                 trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
                 modifier = Modifier.menuAnchor().fillMaxWidth()
             )
             DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
-                City.values().forEach { city ->
+                if (filteredCities.isEmpty()) {
                     DropdownMenuItem(
-                        text = { Text(city.displayName) },
-                        onClick = {
-                            selectedCity = city
-                            expanded = false
-                        }
+                        text = { Text(text = stringResource(id = R.string.no_city_results)) },
+                        enabled = false,
+                        onClick = {}
                     )
+                } else {
+                    filteredCities.forEach { city ->
+                        DropdownMenuItem(
+                            text = { Text(city.displayName) },
+                            onClick = {
+                                selectedCity = city
+                                cityQuery = city.displayName
+                                expanded = false
+                            }
+                        )
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/example/getfast/ui/SettingsScreen.kt
+++ b/app/src/main/java/com/example/getfast/ui/SettingsScreen.kt
@@ -1,12 +1,13 @@
 package com.example.getfast.ui
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
@@ -23,10 +24,10 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.mutableStateListOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -46,10 +47,13 @@ fun SettingsScreen(
     onOpenArchive: () -> Unit,
     onReset: () -> Unit,
 ) {
+    BackHandler(onBack = onBack)
     var selectedCity by remember { mutableStateOf(filter.city) }
+    var cityQuery by remember { mutableStateOf(filter.city.displayName) }
     var priceText by remember { mutableStateOf(filter.maxPrice?.toString() ?: "") }
     var daysText by remember { mutableStateOf(filter.maxAgeDays.toString()) }
     val sources = remember { mutableStateListOf<ListingSource>().apply { addAll(filter.sources) } }
+    val allCities = remember { City.values().toList() }
 
     Column(
         modifier = Modifier
@@ -67,28 +71,60 @@ fun SettingsScreen(
         }
         Spacer(modifier = Modifier.height(16.dp))
         var expanded by remember { mutableStateOf(false) }
+        val filteredCities = remember(cityQuery) {
+            val query = cityQuery.trim()
+            if (query.isEmpty()) {
+                allCities
+            } else {
+                allCities.filter { it.displayName.contains(query, ignoreCase = true) }
+            }
+        }
         ExposedDropdownMenuBox(
             expanded = expanded,
             onExpandedChange = { expanded = !expanded },
             modifier = Modifier.fillMaxWidth()
         ) {
             OutlinedTextField(
-                value = selectedCity.displayName,
-                onValueChange = {},
+                value = cityQuery,
+                onValueChange = { input ->
+                    cityQuery = input
+                    expanded = true
+                    val normalized = input.trim()
+                    val exactMatch = allCities.firstOrNull { city ->
+                        city.displayName.equals(normalized, ignoreCase = true)
+                    }
+                    val suggestions = if (normalized.isEmpty()) allCities else allCities.filter {
+                        it.displayName.contains(normalized, ignoreCase = true)
+                    }
+                    if (exactMatch != null) {
+                        selectedCity = exactMatch
+                    } else if (suggestions.isNotEmpty() && selectedCity !in suggestions) {
+                        selectedCity = suggestions.first()
+                    }
+                },
                 label = { Text(text = stringResource(id = R.string.city_label)) },
-                readOnly = true,
+                singleLine = true,
                 trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
                 modifier = Modifier.menuAnchor().fillMaxWidth()
             )
             DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
-                City.values().forEach { city ->
+                if (filteredCities.isEmpty()) {
                     DropdownMenuItem(
-                        text = { Text(city.displayName) },
-                        onClick = {
-                            selectedCity = city
-                            expanded = false
-                        }
+                        text = { Text(text = stringResource(id = R.string.no_city_results)) },
+                        enabled = false,
+                        onClick = {}
                     )
+                } else {
+                    filteredCities.forEach { city ->
+                        DropdownMenuItem(
+                            text = { Text(city.displayName) },
+                            onClick = {
+                                selectedCity = city
+                                cityQuery = city.displayName
+                                expanded = false
+                            }
+                        )
+                    }
                 }
             }
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -20,6 +20,7 @@
     <string name="max_price_label">Max. Preis (€)</string>
     <string name="max_days_label">Zeitraum (Tage, max. 3)</string>
     <string name="apply_filters">Filter anwenden</string>
+    <string name="no_city_results">Keine Treffer</string>
     <string name="open_settings">Einstellungen</string>
     <string name="settings_title">Einstellungen</string>
     <string name="back">Zurück</string>


### PR DESCRIPTION
## Summary
- allow typing to filter the city dropdowns on the global and provider settings screens and show a message when no matches are found
- keep the selected city in sync with the search query and reuse the current selection when applying filters
- handle system back gestures on the settings and archive screens to return to the home view instead of exiting the app

## Testing
- Not run (missing Gradle wrapper)


------
https://chatgpt.com/codex/tasks/task_e_68d7db79a61883268f6e7687a1200889