### PR TITLE
Enable free-form city selection in settings

### DIFF
--- a/app/src/main/java/com/example/getfast/model/City.kt
+++ b/app/src/main/java/com/example/getfast/model/City.kt
@@ -1,0 +1,281 @@
+package com.example.getfast.model
+
+import java.text.Normalizer
+import java.util.Locale
+
+/**
+ * Represents a selectable city. The [displayName] is shown to the user and used as
+ * search term unless a provider specific override is supplied.
+ */
+data class City(
+    val displayName: String,
+    val isCustom: Boolean = false,
+    private val providerOverrides: Map<ListingSource, String> = emptyMap(),
+) {
+    /**
+     * Returns the provider specific path or query value for this city. Providers that accept
+     * free text queries simply receive the trimmed [displayName], while providers that require
+     * slugs get a generated representation.
+     */
+    fun pathFor(source: ListingSource): String {
+        providerOverrides[source]?.let { return it }
+        val normalized = displayName.trim()
+        return when (source) {
+            ListingSource.WOHNUNGSBOERSE -> normalized.toWohnungsboerseSlug()
+            ListingSource.KLEINANZEIGEN -> normalized
+            ListingSource.IMMOSCOUT,
+            ListingSource.IMMONET,
+            ListingSource.IMMOWELT -> normalized
+        }
+    }
+
+    companion object {
+        fun custom(name: String): City = City(name.trim(), isCustom = true)
+    }
+}
+
+/**
+ * Collection of popular German cities sorted by population. The order is preserved so that
+ * autocomplete suggestions naturally appear by relevance.
+ */
+object CityCatalog {
+    val germany: List<City> = listOf(
+        City("Berlin"),
+        City("Hamburg"),
+        City("München"),
+        City("Köln"),
+        City("Frankfurt am Main"),
+        City("Stuttgart"),
+        City("Düsseldorf"),
+        City("Leipzig"),
+        City("Dortmund"),
+        City("Essen"),
+        City("Bremen"),
+        City("Dresden"),
+        City("Hannover"),
+        City("Nürnberg"),
+        City("Duisburg"),
+        City("Bochum"),
+        City("Wuppertal"),
+        City("Bielefeld"),
+        City("Bonn"),
+        City("Münster"),
+        City("Karlsruhe"),
+        City("Mannheim"),
+        City("Augsburg"),
+        City("Wiesbaden"),
+        City("Gelsenkirchen"),
+        City("Mönchengladbach"),
+        City("Braunschweig"),
+        City("Chemnitz"),
+        City("Kiel"),
+        City("Aachen"),
+        City("Halle (Saale)"),
+        City("Magdeburg"),
+        City("Freiburg im Breisgau"),
+        City("Krefeld"),
+        City("Lübeck"),
+        City("Oberhausen"),
+        City("Erfurt"),
+        City("Mainz"),
+        City("Rostock"),
+        City("Kassel"),
+        City("Hagen"),
+        City("Saarbrücken"),
+        City("Hamm"),
+        City("Potsdam"),
+        City("Ludwigshafen am Rhein"),
+        City("Oldenburg"),
+        City("Leverkusen"),
+        City("Osnabrück"),
+        City("Solingen"),
+        City("Heidelberg"),
+        City("Herne"),
+        City("Neuss"),
+        City("Darmstadt"),
+        City("Paderborn"),
+        City("Regensburg"),
+        City("Ingolstadt"),
+        City("Würzburg"),
+        City("Fürth"),
+        City("Ulm"),
+        City("Heilbronn"),
+        City("Pforzheim"),
+        City("Wolfsburg"),
+        City("Göttingen"),
+        City("Offenbach am Main"),
+        City("Bottrop"),
+        City("Reutlingen"),
+        City("Trier"),
+        City("Recklinghausen"),
+        City("Bremerhaven"),
+        City("Koblenz"),
+        City("Bergisch Gladbach"),
+        City("Jena"),
+        City("Remscheid"),
+        City("Erlangen"),
+        City("Moers"),
+        City("Siegen"),
+        City("Hildesheim"),
+        City("Salzgitter"),
+        City("Cottbus"),
+        City("Kaiserslautern"),
+        City("Gütersloh"),
+        City("Witten"),
+        City("Hanau"),
+        City("Schwerin"),
+        City("Gera"),
+        City("Esslingen am Neckar"),
+        City("Iserlohn"),
+        City("Ludwigsburg"),
+        City("Marl"),
+        City("Düren"),
+        City("Tübingen"),
+        City("Villingen-Schwenningen"),
+        City("Flensburg"),
+        City("Gießen"),
+        City("Dessau-Roßlau"),
+        City("Ratingen"),
+        City("Lünen"),
+        City("Wilhelmshaven"),
+        City("Minden"),
+        City("Neumünster"),
+        City("Dormagen"),
+        City("Bayreuth"),
+        City("Landshut"),
+        City("Aschaffenburg"),
+        City("Kempten (Allgäu)"),
+        City("Lüneburg"),
+        City("Bamberg"),
+        City("Aalen"),
+        City("Langenfeld (Rheinland)"),
+        City("Fulda"),
+        City("Neubrandenburg"),
+        City("Konstanz"),
+        City("Rheine"),
+        City("Grevenbroich"),
+        City("Weimar"),
+        City("Herten"),
+        City("Frankfurt (Oder)"),
+        City("Bergkamen"),
+        City("Speyer"),
+        City("Coburg"),
+        City("Ravensburg"),
+        City("Bocholt"),
+        City("Delmenhorst"),
+        City("Rosenheim"),
+        City("Erftstadt"),
+        City("Wesel"),
+        City("Garbsen"),
+        City("Hürth"),
+        City("Hilden"),
+        City("Gladbeck"),
+        City("Sindelfingen"),
+        City("Norderstedt"),
+        City("Troisdorf"),
+        City("Friedrichshafen"),
+        City("Passau"),
+        City("Görlitz"),
+        City("Gummersbach"),
+        City("Cloppenburg"),
+        City("Bad Homburg vor der Höhe"),
+        City("Celle"),
+        City("Velbert"),
+        City("Herford"),
+        City("Lippstadt"),
+        City("Baden-Baden"),
+        City("Wolfenbüttel"),
+        City("Nordhorn"),
+        City("Kleve"),
+        City("Bünde"),
+        City("Neustadt an der Weinstraße"),
+        City("Dinslaken"),
+        City("Heidenheim an der Brenz"),
+        City("Langenhagen"),
+        City("Bad Salzuflen"),
+        City("Euskirchen"),
+        City("Herzogenrath"),
+        City("Sankt Augustin"),
+        City("Rheda-Wiedenbrück"),
+        City("Unna"),
+        City("Schweinfurt"),
+        City("Stralsund"),
+        City("Hameln"),
+        City("Straubing"),
+        City("Neunkirchen"),
+        City("Goslar"),
+        City("Waiblingen"),
+        City("Amberg"),
+        City("Freising"),
+        City("Hof"),
+        City("Böblingen"),
+        City("Lörrach"),
+        City("Offenburg"),
+        City("Schwabach"),
+        City("Aurich"),
+        City("Ansbach"),
+        City("Plauen"),
+        City("Zwickau"),
+        City("Singen (Hohentwiel)"),
+        City("Emden"),
+        City("Greifswald"),
+        City("Cuxhaven"),
+        City("Marburg"),
+        City("Tönisvorst"),
+        City("Vechta"),
+        City("Lemgo"),
+        City("Rastatt"),
+        City("Papenburg"),
+        City("Völklingen"),
+        City("Lindau (Bodensee)"),
+        City("Stade"),
+        City("Homburg"),
+        City("Bitterfeld-Wolfen"),
+        City("Freital"),
+        City("Gotha"),
+        City("Halberstadt"),
+        City("Rottweil"),
+        City("Weiden in der Oberpfalz"),
+        City("Deggendorf"),
+        City("Lingen (Ems)"),
+        City("Ahaus"),
+    )
+
+    val defaultCity: City = germany.first()
+
+    fun findByName(name: String): City? {
+        val normalized = name.trim()
+        if (normalized.isEmpty()) return null
+        return germany.firstOrNull { it.displayName.equals(normalized, ignoreCase = true) }
+    }
+}
+
+private fun String.toWohnungsboerseSlug(): String {
+    if (isBlank()) return ""
+    return toNormalizedParts().joinToString("-") { part ->
+        part.lowercase(Locale.GERMANY).replaceFirstChar { char ->
+            if (char.isLowerCase()) char.titlecase(Locale.GERMANY) else char.toString()
+        }
+    }
+}
+
+private fun String.toNormalizedParts(): List<String> {
+    val base = Normalizer.normalize(trim(), Normalizer.Form.NFD)
+        .replace("ß", "ss")
+        .replace("Ä", "Ae")
+        .replace("Ö", "Oe")
+        .replace("Ü", "Ue")
+        .replace("ä", "ae")
+        .replace("ö", "oe")
+        .replace("ü", "ue")
+    return base
+        .replace("'", " ")
+        .replace("/", " ")
+        .split(" ", "-", ",", ".")
+        .map { part ->
+            val stripped = Normalizer.normalize(part, Normalizer.Form.NFD)
+                .replace("\p{Mn}".toRegex(), "")
+            stripped.replace("[^A-Za-z0-9]".toRegex(), "")
+        }
+        .filter { it.isNotEmpty() }
+}

--- a/app/src/main/java/com/example/getfast/model/SearchFilter.kt
+++ b/app/src/main/java/com/example/getfast/model/SearchFilter.kt
@@ -10,94 +10,11 @@ package com.example.getfast.model
  *                       be discarded. The value is capped at 3 days.
  */
 data class SearchFilter(
-    val city: City = City.BERLIN,
+    val city: City = CityCatalog.defaultCity,
     val maxPrice: Int? = null,
     val maxAgeDays: Int = 3,
     val sources: Set<ListingSource> = ListingSource.values().toSet(),
 )
-
-/**
- * Supported cities and the provider specific URL paths or identifiers
- * used to build search URLs.
- */
-enum class City(
-    val displayName: String,
-    private val providerPaths: Map<ListingSource, String>
-) {
-    BERLIN(
-        "Berlin",
-        mapOf(
-            ListingSource.KLEINANZEIGEN to "berlin/c203l3331",
-            ListingSource.IMMOSCOUT to "Berlin",
-            ListingSource.IMMONET to "berlin",
-            ListingSource.IMMOWELT to "berlin",
-            ListingSource.WOHNUNGSBOERSE to "berlin",
-        ),
-    ),
-    HAMBURG(
-        "Hamburg",
-        mapOf(
-            ListingSource.KLEINANZEIGEN to "hamburg/c203l9409",
-            ListingSource.IMMOSCOUT to "Hamburg",
-            ListingSource.IMMONET to "hamburg",
-            ListingSource.IMMOWELT to "hamburg",
-            ListingSource.WOHNUNGSBOERSE to "hamburg",
-        ),
-    ),
-    MUNICH(
-        "München",
-        mapOf(
-            ListingSource.KLEINANZEIGEN to "muenchen/c203l6436",
-            ListingSource.IMMOSCOUT to "München",
-            ListingSource.IMMONET to "muenchen",
-            ListingSource.IMMOWELT to "muenchen",
-            ListingSource.WOHNUNGSBOERSE to "muenchen",
-        ),
-    ),
-    COLOGNE(
-        "Köln",
-        mapOf(
-            ListingSource.KLEINANZEIGEN to "koeln/c203l9480",
-            ListingSource.IMMOSCOUT to "Köln",
-            ListingSource.IMMONET to "koeln",
-            ListingSource.IMMOWELT to "koeln",
-            ListingSource.WOHNUNGSBOERSE to "koeln",
-        ),
-    ),
-    FRANKFURT(
-        "Frankfurt am Main",
-        mapOf(
-            ListingSource.KLEINANZEIGEN to "frankfurt-main/c203l1723",
-            ListingSource.IMMOSCOUT to "Frankfurt am Main",
-            ListingSource.IMMONET to "frankfurt-am-main",
-            ListingSource.IMMOWELT to "frankfurt-am-main",
-            ListingSource.WOHNUNGSBOERSE to "frankfurt-am-main",
-        ),
-    ),
-    STUTTGART(
-        "Stuttgart",
-        mapOf(
-            ListingSource.KLEINANZEIGEN to "stuttgart/c203l11538",
-            ListingSource.IMMOSCOUT to "Stuttgart",
-            ListingSource.IMMONET to "stuttgart",
-            ListingSource.IMMOWELT to "stuttgart",
-            ListingSource.WOHNUNGSBOERSE to "stuttgart",
-        ),
-    ),
-    DUSSELDORF(
-        "Düsseldorf",
-        mapOf(
-            ListingSource.KLEINANZEIGEN to "duesseldorf/c203l9435",
-            ListingSource.IMMOSCOUT to "Düsseldorf",
-            ListingSource.IMMONET to "duesseldorf",
-            ListingSource.IMMOWELT to "duesseldorf",
-            ListingSource.WOHNUNGSBOERSE to "duesseldorf",
-        ),
-    );
-
-    fun pathFor(source: ListingSource): String =
-        providerPaths[source] ?: displayName
-}
 
 /**
  * Supported listing sources.

--- a/app/src/main/java/com/example/getfast/repository/KleinanzeigenProvider.kt
+++ b/app/src/main/java/com/example/getfast/repository/KleinanzeigenProvider.kt
@@ -3,6 +3,8 @@ package com.example.getfast.repository
 import com.example.getfast.model.Listing
 import com.example.getfast.model.ListingSource
 import com.example.getfast.model.SearchFilter
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
 
 /**
  * Provider für Anzeigen von eBay Kleinanzeigen.
@@ -28,8 +30,11 @@ class KleinanzeigenProvider(
      * Erzeugt die URL für die Kleinanzeigen-Suche.
      */
     private fun buildRequestUrl(filter: SearchFilter): String {
-        val path = filter.city.pathFor(source)
-        return "https://www.kleinanzeigen.de/s-wohnung-mieten/$path"
+        val location = URLEncoder.encode(
+            filter.city.pathFor(source),
+            StandardCharsets.UTF_8.toString()
+        )
+        return "https://www.kleinanzeigen.de/s-wohnung-mieten/c203l0?locationStr=$location&radius=0"
     }
 }
 

--- a/app/src/main/java/com/example/getfast/ui/ProviderSettingsScreen.kt
+++ b/app/src/main/java/com/example/getfast/ui/ProviderSettingsScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.example.getfast.R
 import com.example.getfast.model.City
+import com.example.getfast.model.CityCatalog
 import com.example.getfast.model.SearchFilter
 
 /**
@@ -47,12 +48,13 @@ fun ProviderSettingsScreen(
     onBack: () -> Unit,
 ) {
     BackHandler(onBack = onBack)
-    var selectedCity by remember { mutableStateOf(filter.city) }
-    var cityQuery by remember { mutableStateOf(filter.city.displayName) }
+    val allCities = remember { CityCatalog.germany }
+    var selectedCity by remember(filter.city) {
+        mutableStateOf(CityCatalog.findByName(filter.city.displayName) ?: filter.city)
+    }
+    var cityQuery by remember { mutableStateOf(selectedCity.displayName) }
     var priceText by remember { mutableStateOf(filter.maxPrice?.toString() ?: "") }
     var daysText by remember { mutableStateOf(filter.maxAgeDays.toString()) }
-    val allCities = remember { City.values().toList() }
-
     Column(
         modifier = Modifier
             .fillMaxSize()
@@ -91,13 +93,10 @@ fun ProviderSettingsScreen(
                     val exactMatch = allCities.firstOrNull { city ->
                         city.displayName.equals(normalized, ignoreCase = true)
                     }
-                    val suggestions = if (normalized.isEmpty()) allCities else allCities.filter {
-                        it.displayName.contains(normalized, ignoreCase = true)
-                    }
-                    if (exactMatch != null) {
-                        selectedCity = exactMatch
-                    } else if (suggestions.isNotEmpty() && selectedCity !in suggestions) {
-                        selectedCity = suggestions.first()
+                    selectedCity = when {
+                        exactMatch != null -> exactMatch
+                        normalized.isEmpty() -> selectedCity
+                        else -> City.custom(input)
                     }
                 },
                 label = { Text(text = stringResource(id = R.string.city_label)) },
@@ -105,24 +104,41 @@ fun ProviderSettingsScreen(
                 trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
                 modifier = Modifier.menuAnchor().fillMaxWidth()
             )
+            val trimmedQuery = cityQuery.trim()
+            val hasExactMatch = filteredCities.any { city ->
+                city.displayName.equals(trimmedQuery, ignoreCase = true)
+            }
+            val shouldOfferCustom = trimmedQuery.isNotEmpty() && !hasExactMatch
+
             DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
-                if (filteredCities.isEmpty()) {
+                filteredCities.forEach { city ->
+                    DropdownMenuItem(
+                        text = { Text(city.displayName) },
+                        onClick = {
+                            selectedCity = city
+                            cityQuery = city.displayName
+                            expanded = false
+                        }
+                    )
+                }
+
+                if (shouldOfferCustom) {
+                    DropdownMenuItem(
+                        text = { Text(stringResource(id = R.string.use_custom_city, trimmedQuery)) },
+                        onClick = {
+                            selectedCity = City.custom(trimmedQuery)
+                            cityQuery = trimmedQuery
+                            expanded = false
+                        }
+                    )
+                }
+
+                if (filteredCities.isEmpty() && !shouldOfferCustom) {
                     DropdownMenuItem(
                         text = { Text(text = stringResource(id = R.string.no_city_results)) },
                         enabled = false,
                         onClick = {}
                     )
-                } else {
-                    filteredCities.forEach { city ->
-                        DropdownMenuItem(
-                            text = { Text(city.displayName) },
-                            onClick = {
-                                selectedCity = city
-                                cityQuery = city.displayName
-                                expanded = false
-                            }
-                        )
-                    }
                 }
             }
         }

--- a/app/src/main/java/com/example/getfast/ui/SettingsScreen.kt
+++ b/app/src/main/java/com/example/getfast/ui/SettingsScreen.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.example.getfast.R
 import com.example.getfast.model.City
+import com.example.getfast.model.CityCatalog
 import com.example.getfast.model.ListingSource
 import com.example.getfast.model.SearchFilter
 
@@ -55,14 +56,13 @@ data class SettingsScreenState(
      */
     val filteredCities: List<City>
         get() {
-            // Wir trimmen den Text, um sowohl führende als auch abschließende Leerzeichen zu ignorieren.
             val trimmedQuery = cityQuery.trim()
             return if (trimmedQuery.isEmpty()) {
-                // Ohne Suchtext zeigen wir alle Städte an.
                 allCities
             } else {
-                // Mit Suchtext filtern wir nach Übereinstimmungen im Namen.
-                allCities.filter { city -> city.displayName.contains(trimmedQuery, ignoreCase = true) }
+                allCities.filter { city ->
+                    city.displayName.contains(trimmedQuery, ignoreCase = true)
+                }
             }
         }
 
@@ -79,24 +79,15 @@ data class SettingsScreenState(
      */
     fun updateCityQuery(newQuery: String): SettingsScreenState {
         val normalized = newQuery.trim()
-        val suggestions = if (normalized.isEmpty()) {
-            allCities
-        } else {
-            allCities.filter { city -> city.displayName.contains(normalized, ignoreCase = true) }
-        }
         val exactMatch = allCities.firstOrNull { city ->
             city.displayName.equals(normalized, ignoreCase = true)
         }
         val updatedCity = when {
             exactMatch != null -> exactMatch
-            suggestions.isNotEmpty() && selectedCity !in suggestions -> suggestions.first()
-            else -> selectedCity
+            normalized.isEmpty() -> selectedCity
+            else -> City.custom(newQuery)
         }
-        // Wir geben den neuen Text und die potenziell aktualisierte Stadt zurück.
-        return copy(
-            cityQuery = newQuery,
-            selectedCity = updatedCity,
-        )
+        return copy(cityQuery = newQuery, selectedCity = updatedCity)
     }
 
     /**
@@ -138,14 +129,18 @@ data class SettingsScreenState(
 /**
  * Erzeugt den Startzustand für den Screen basierend auf dem übergebenen Filter.
  */
-fun createInitialSettingsScreenState(filter: SearchFilter): SettingsScreenState = SettingsScreenState(
-    selectedCity = filter.city,
-    cityQuery = filter.city.displayName,
-    priceText = filter.maxPrice?.toString() ?: "",
-    daysText = filter.maxAgeDays.toString(),
-    selectedSources = filter.sources,
-    allCities = City.values().toList(),
-)
+fun createInitialSettingsScreenState(filter: SearchFilter): SettingsScreenState {
+    val knownCity = CityCatalog.findByName(filter.city.displayName)
+    val selectedCity = knownCity ?: filter.city
+    return SettingsScreenState(
+        selectedCity = selectedCity,
+        cityQuery = selectedCity.displayName,
+        priceText = filter.maxPrice?.toString() ?: "",
+        daysText = filter.maxAgeDays.toString(),
+        selectedSources = filter.sources,
+        allCities = CityCatalog.germany,
+    )
+}
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -269,16 +264,14 @@ private fun CitySelectorSection(
                 .fillMaxWidth()
         )
 
+        val query = state.cityQuery.trim()
+        val hasExactMatch = state.filteredCities.any { city ->
+            city.displayName.equals(query, ignoreCase = true)
+        }
+        val shouldOfferCustomCity = query.isNotEmpty() && !hasExactMatch
+
         DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
-            if (state.filteredCities.isEmpty()) {
-                // Keine Ergebnisse gefunden, daher deaktivierten Hinweis anzeigen.
-                DropdownMenuItem(
-                    text = { Text(text = stringResource(id = R.string.no_city_results)) },
-                    enabled = false,
-                    onClick = {},
-                )
-            } else {
-                // Für jede Stadt einen Menüeintrag anzeigen.
+            if (state.filteredCities.isNotEmpty()) {
                 state.filteredCities.forEach { city ->
                     DropdownMenuItem(
                         text = { Text(city.displayName) },
@@ -288,6 +281,24 @@ private fun CitySelectorSection(
                         }
                     )
                 }
+            }
+
+            if (shouldOfferCustomCity) {
+                DropdownMenuItem(
+                    text = { Text(stringResource(id = R.string.use_custom_city, query)) },
+                    onClick = {
+                        onExpandedCityChosen(City.custom(query))
+                        expanded = false
+                    }
+                )
+            }
+
+            if (state.filteredCities.isEmpty() && !shouldOfferCustomCity) {
+                DropdownMenuItem(
+                    text = { Text(text = stringResource(id = R.string.no_city_results)) },
+                    enabled = false,
+                    onClick = {},
+                )
             }
         }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -21,6 +21,7 @@
     <string name="max_days_label">Zeitraum (Tage, max. 3)</string>
     <string name="apply_filters">Filter anwenden</string>
     <string name="no_city_results">Keine Treffer</string>
+    <string name="use_custom_city">%1$s verwenden</string>
     <string name="open_settings">Einstellungen</string>
     <string name="settings_title">Einstellungen</string>
     <string name="back">Zurück</string>


### PR DESCRIPTION
## Summary
- allow users to choose any German city by backing the city picker with a curated catalogue and free-text entries
- update both settings screens to surface autocomplete suggestions and custom city options while keeping selections in sync
- adjust provider URL building, notably for Kleinanzeigen, so that free-form city names are accepted during listing searches

## Testing
- ./gradlew test *(fails: gradlew wrapper not present in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68d7e5b450108326b18f2b78e90f9e08