### PR TITLE
Allow selecting German cities without diacritics

### DIFF
--- a/app/src/main/java/com/example/getfast/model/City.kt
+++ b/app/src/main/java/com/example/getfast/model/City.kt
@@ -12,6 +12,21 @@ data class City(
     val isCustom: Boolean = false,
     private val providerOverrides: Map<ListingSource, String> = emptyMap(),
 ) {
+    private val normalizedName: String = normalize(displayName)
+
+    fun matchesQuery(query: String): Boolean {
+        if (query.isBlank()) return true
+        val normalizedQuery = normalize(query)
+        if (normalizedQuery.isEmpty()) return false
+        return normalizedName.contains(normalizedQuery)
+    }
+
+    fun matchesName(name: String): Boolean {
+        val normalized = normalize(name)
+        if (normalized.isEmpty()) return false
+        return normalizedName == normalized
+    }
+
     /**
      * Returns the provider specific path or query value for this city. Providers that accept
      * free text queries simply receive the trimmed [displayName], while providers that require
@@ -30,6 +45,18 @@ data class City(
     }
 
     companion object {
+        private val DIACRITICS_REGEX = "\\p{InCombiningDiacriticalMarks}+".toRegex()
+
+        internal fun normalize(value: String): String {
+            val trimmed = value.trim()
+            if (trimmed.isEmpty()) return ""
+            val normalized = Normalizer.normalize(trimmed, Normalizer.Form.NFD)
+            val withoutDiacritics = DIACRITICS_REGEX.replace(normalized, "")
+            return withoutDiacritics
+                .replace("ß", "ss")
+                .lowercase(Locale.GERMAN)
+        }
+
         fun custom(name: String): City = City(name.trim(), isCustom = true)
     }
 }
@@ -49,9 +76,8 @@ object CityCatalog {
     val defaultCity: City = germany.first()
 
     fun findByName(name: String): City? {
-        val normalized = name.trim()
-        if (normalized.isEmpty()) return null
-        return germany.firstOrNull { it.displayName.equals(normalized, ignoreCase = true) }
+        if (name.isBlank()) return null
+        return germany.firstOrNull { it.matchesName(name) }
     }
 }
 

--- a/app/src/main/java/com/example/getfast/ui/ProviderSettingsScreen.kt
+++ b/app/src/main/java/com/example/getfast/ui/ProviderSettingsScreen.kt
@@ -76,7 +76,7 @@ fun ProviderSettingsScreen(
             if (query.isEmpty()) {
                 allCities
             } else {
-                allCities.filter { it.displayName.contains(query, ignoreCase = true) }
+                allCities.filter { it.matchesQuery(query) }
             }
         }
         ExposedDropdownMenuBox(
@@ -89,10 +89,7 @@ fun ProviderSettingsScreen(
                 onValueChange = { input ->
                     cityQuery = input
                     expanded = true
-                    val normalized = input.trim()
-                    val exactMatch = allCities.firstOrNull { city ->
-                        city.displayName.equals(normalized, ignoreCase = true)
-                    }
+                    val exactMatch = allCities.firstOrNull { city -> city.matchesName(input) }
                     selectedCity = exactMatch ?: selectedCity
                 },
                 label = { Text(text = stringResource(id = R.string.city_label)) },

--- a/app/src/main/java/com/example/getfast/ui/SettingsScreen.kt
+++ b/app/src/main/java/com/example/getfast/ui/SettingsScreen.kt
@@ -60,9 +60,7 @@ data class SettingsScreenState(
             return if (trimmedQuery.isEmpty()) {
                 allCities
             } else {
-                allCities.filter { city ->
-                    city.displayName.contains(trimmedQuery, ignoreCase = true)
-                }
+                allCities.filter { city -> city.matchesQuery(trimmedQuery) }
             }
         }
 
@@ -78,10 +76,7 @@ data class SettingsScreenState(
      * Hilfsfunktion zur Aktualisierung der Suchanfrage und der intern ausgewählten Stadt.
      */
     fun updateCityQuery(newQuery: String): SettingsScreenState {
-        val normalized = newQuery.trim()
-        val exactMatch = allCities.firstOrNull { city ->
-            city.displayName.equals(normalized, ignoreCase = true)
-        }
+        val exactMatch = allCities.firstOrNull { city -> city.matchesName(newQuery) }
         val updatedCity = exactMatch ?: selectedCity
         return copy(cityQuery = newQuery, selectedCity = updatedCity)
     }

--- a/app/src/test/java/com/example/getfast/model/CityCatalogTest.kt
+++ b/app/src/test/java/com/example/getfast/model/CityCatalogTest.kt
@@ -1,0 +1,35 @@
+package com.example.getfast.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CityCatalogTest {
+
+    @Test
+    fun germany_containsExpectedCities() {
+        val cityNames = CityCatalog.germany.map { it.displayName }
+        assertEquals(listOf("Berlin", "Hamburg", "München", "Köln"), cityNames)
+    }
+
+    @Test
+    fun findByName_matchesDiacriticInsensitiveInput() {
+        val munich = CityCatalog.findByName("Munchen")
+        val cologne = CityCatalog.findByName("koln")
+
+        assertNotNull(munich)
+        assertEquals("München", munich!!.displayName)
+
+        assertNotNull(cologne)
+        assertEquals("Köln", cologne!!.displayName)
+    }
+
+    @Test
+    fun matchesQuery_handlesNormalizedInput() {
+        val munich = City("München")
+        assertTrue(munich.matchesQuery("Mun"))
+        assertTrue(munich.matchesQuery("munchen"))
+    }
+}
+


### PR DESCRIPTION
## Summary
- normalize city names to allow diacritic-insensitive matching for Berlin, Hamburg, München and Köln
- use the new matching helpers in the global and provider settings screens
- add unit coverage that ensures the configured cities are selectable via normalized input

## Testing
- ./gradlew test *(fails: wrapper script not present in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68d81faa4ec48326bf1ac8edacfb4994