### PR TITLE
Filter listings by selected city

### DIFF
--- a/app/src/main/java/com/example/getfast/repository/ListingRepository.kt
+++ b/app/src/main/java/com/example/getfast/repository/ListingRepository.kt
@@ -1,5 +1,6 @@
 package com.example.getfast.repository
 
+import com.example.getfast.model.City
 import com.example.getfast.model.Listing
 import com.example.getfast.model.ListingSource
 import com.example.getfast.model.SearchFilter
@@ -21,9 +22,28 @@ class ListingRepository(
      */
     suspend fun fetchLatestListingsMatchingFilter(filter: SearchFilter): List<Listing> {
         val listingsFromProviders = collectListingsFromSelectedSources(filter)
-        val priceFilteredListings = applyMaxPriceFilter(listingsFromProviders, filter.maxPrice)
+        val cityFilteredListings = applyCityFilter(listingsFromProviders, filter.city)
+        val priceFilteredListings = applyMaxPriceFilter(cityFilteredListings, filter.maxPrice)
         val maxDays = filter.maxAgeDays.coerceAtMost(3)
         return applyMaxAgeFilter(priceFilteredListings, maxDays)
+    }
+
+    /**
+     * Entfernt Listings, die nicht zur ausgewählten Stadt passen.
+     */
+    private fun applyCityFilter(listings: List<Listing>, city: City): List<Listing> {
+        val normalizedTarget = City.normalize(city.displayName)
+        if (normalizedTarget.isEmpty()) {
+            return listings
+        }
+        return listings.filter { listing ->
+            val normalizedListingCity = City.normalize(listing.city)
+            normalizedListingCity.isNotEmpty() && (
+                normalizedListingCity == normalizedTarget ||
+                    normalizedListingCity.contains(normalizedTarget) ||
+                    normalizedTarget.contains(normalizedListingCity)
+                )
+        }
     }
 
     /**

--- a/app/src/test/java/com/example/getfast/ListingRepositoryTest.kt
+++ b/app/src/test/java/com/example/getfast/ListingRepositoryTest.kt
@@ -1,7 +1,9 @@
 package com.example.getfast
 
-import com.example.getfast.model.SearchFilter
+import com.example.getfast.model.CityCatalog
+import com.example.getfast.model.Listing
 import com.example.getfast.model.ListingSource
+import com.example.getfast.model.SearchFilter
 import com.example.getfast.repository.HtmlFetcher
 import com.example.getfast.repository.ImmoscoutListingParser
 import com.example.getfast.repository.ImmoscoutProvider
@@ -14,6 +16,7 @@ import com.example.getfast.repository.ListingRepository
 import com.example.getfast.repository.WohnungsboerseProvider
 import com.example.getfast.repository.KleinanzeigenListingParser
 import com.example.getfast.repository.WohnungsboerseListingParser
+import com.example.getfast.repository.ListingProvider
 import kotlinx.coroutines.runBlocking
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
@@ -22,6 +25,13 @@ import org.junit.Test
 
 private class FakeFetcher(private val html: String) : HtmlFetcher {
     override suspend fun fetch(url: String): Document = Jsoup.parse(html)
+}
+
+private class FakeListingProvider(
+    override val source: ListingSource,
+    private val listings: List<Listing>,
+) : ListingProvider {
+    override suspend fun fetchListingsForFilter(filter: SearchFilter): List<Listing> = listings
 }
 
 class ListingRepositoryTest {
@@ -98,6 +108,56 @@ class ListingRepositoryTest {
         val first = listings[0]
         assertEquals("Boerse 1", first.title)
         assertEquals("500 €", first.price)
+    }
+
+    @Test
+    fun fetchLatestListings_filtersBySelectedCity() = runBlocking {
+        val provider = FakeListingProvider(
+            source = ListingSource.KLEINANZEIGEN,
+            listings = listOf(
+                Listing(
+                    id = "1",
+                    title = "Hamburg Mitte",
+                    url = "https://example.com/1",
+                    date = "",
+                    district = "Mitte",
+                    city = "Hamburg",
+                    price = "100 €",
+                    summary = "",
+                ),
+                Listing(
+                    id = "2",
+                    title = "Berlin Mitte",
+                    url = "https://example.com/2",
+                    date = "",
+                    district = "Mitte",
+                    city = "Berlin",
+                    price = "100 €",
+                    summary = "",
+                ),
+                Listing(
+                    id = "3",
+                    title = "Hamburg Barmbek",
+                    url = "https://example.com/3",
+                    date = "",
+                    district = "Barmbek",
+                    city = "Hamburg - Barmbek",
+                    price = "100 €",
+                    summary = "",
+                ),
+            ),
+        )
+        val hamburg = CityCatalog.findByName("Hamburg")!!
+        val filter = SearchFilter(
+            city = hamburg,
+            sources = setOf(ListingSource.KLEINANZEIGEN),
+        )
+        val repo = ListingRepository(providers = mapOf(ListingSource.KLEINANZEIGEN to provider))
+
+        val listings = repo.fetchLatestListingsMatchingFilter(filter)
+
+        val ids = listings.map { it.id }.sorted()
+        assertEquals(listOf("1", "3"), ids)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- filter repository results so only listings from the selected city are kept
- cover the new city-filtering behaviour with a dedicated repository test

## Testing
- `./gradlew test` *(fails: bash: ./gradlew: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68d83ab69f148326ac9baf5e29991fae