### PR TITLE
Populate missing city values during provider fetch

### DIFF
--- a/app/src/main/java/com/example/getfast/repository/KleinanzeigenProvider.kt
+++ b/app/src/main/java/com/example/getfast/repository/KleinanzeigenProvider.kt
@@ -20,7 +20,14 @@ class KleinanzeigenProvider(
         val url = buildRequestUrl(filter)
         return runCatching {
             val document = fetcher.fetch(url)
-            parser.parseListingsFromDocument(document)
+            val parsedListings = parser.parseListingsFromDocument(document)
+            parsedListings.map { listing ->
+                if (listing.city.isBlank()) {
+                    listing.copy(city = filter.city.displayName)
+                } else {
+                    listing
+                }
+            }
         }.getOrElse { emptyList() }
     }
 

--- a/app/src/test/java/com/example/getfast/KleinanzeigenProviderTest.kt
+++ b/app/src/test/java/com/example/getfast/KleinanzeigenProviderTest.kt
@@ -1,0 +1,46 @@
+package com.example.getfast
+
+import com.example.getfast.model.City
+import com.example.getfast.model.Listing
+import com.example.getfast.model.SearchFilter
+import com.example.getfast.repository.HtmlFetcher
+import com.example.getfast.repository.KleinanzeigenProvider
+import com.example.getfast.repository.ProviderListingParser
+import kotlinx.coroutines.runBlocking
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+private class StaticHtmlFetcher : HtmlFetcher {
+    override suspend fun fetch(url: String): Document = Jsoup.parse("<html></html>")
+}
+
+private class StubParser(private val listings: List<Listing>) : ProviderListingParser {
+    override fun parseListingsFromDocument(document: Document): List<Listing> = listings
+}
+
+class KleinanzeigenProviderTest {
+    @Test
+    fun fetchListingsForFilter_populatesMissingCityFromFilter() = runBlocking {
+        val filter = SearchFilter(city = City("Berlin"))
+        val listingWithoutCity = Listing(
+            id = "1",
+            title = "Test",
+            url = "https://example.com",
+            date = "",
+            district = "Mitte",
+            city = "",
+            price = "100 €",
+            summary = "",
+        )
+        val provider = KleinanzeigenProvider(
+            fetcher = StaticHtmlFetcher(),
+            parser = StubParser(listOf(listingWithoutCity)),
+        )
+
+        val listings = provider.fetchListingsForFilter(filter)
+
+        assertEquals(listOf("Berlin"), listings.map { it.city })
+    }
+}


### PR DESCRIPTION
## Summary
- ensure the Kleinanzeigen provider assigns the selected city when the parsed listing omits a location
- keep the repository focused on filtering logic by reverting the earlier in-repo fallback
- cover the provider-level behavior with a new unit test and remove the outdated repository test

## Testing
- Not run (Gradle wrapper script is not present in the repository)


------
https://chatgpt.com/codex/tasks/task_e_68d840ccf7f8832693fe6fd826bb91fb